### PR TITLE
Missing cmd on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ this image on a system with the simplefs kernel module installed.
 ```shell
 $ mkdir -p test
 $ dd if=/dev/zero of=test.img bs=1M count=50
+$ ./mkfs.simplefs test.img
 $ sudo mount -o loop -t simplefs test.img test
 ```
 


### PR DESCRIPTION
if you follow readme cmd, you will get "permission deny" and "Wrong magic number" error.

The reason is the file need to be format before mounting it.
If you didn't format it, csb->magic would get 0 because we create with /dev/zero

It's fine when using make test.img