### PR TITLE
Fix the ret value when wrong magic number error occur

### DIFF
--- a/super.c
+++ b/super.c
@@ -208,7 +208,7 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent)
     /* Check magic number */
     if (csb->magic != sb->s_magic) {
         pr_err("Wrong magic number\n");
-        ret = -EPERM;
+        ret = -EINVAL;
         goto release;
     }
 


### PR DESCRIPTION
Difference between this modification when mounting simplefs
with wrong fs type:

Before:
```
    mount: /home/yoyi/simplefs/test: permission denied.
```
After:
```
    mount: /home/yoyi/simplefs/test: wrong fs type,
    bad option, bad superblock on /dev/loop17,
    missing codepage or helper program, or other error.
```