### PR TITLE
Improve create many files test

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -8,7 +8,8 @@ MKFS=$3
 D_MOD="drwxr-xr-x"
 F_MOD="-rw-r--r--"
 S_MOD="lrwxrwxrwx"
-MAXFILESIZE=4194304
+MAXFILESIZE=4194304 # 4MiB
+MAXFILES=128        # max files per dir
 
 test_op() {
     local op=$1 
@@ -53,10 +54,13 @@ test_op 'mkdir dir' # expected to fail
 test_op 'touch file'
 
 # create 128 files
-for i in {0..124}
+for ((i=0; i<=$MAXFILES; i++))
 do
     test_op "touch $i.txt" # expected to fail with more than 128 files
 done
+filecnts=$(ls | wc -w)
+test $filecnts -eq $MAXFILES || echo "Failed, it should be $MAXFILES files"
+sudo rm [0-9]*.txt
 
 # hard link
 test_op 'ln file hdlink'


### PR DESCRIPTION
Check if the number of file is equal to the maximum number of files a directory can have.

Remove the files create in this test so following tests wouldn't be interfere by it.
(Originally, the symlink test would be interfere by it.)

By the way, I notice that `ls -a` won't show `.` and `..`, should it be list in TODO?
