### PR TITLE
Support for extents

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,3 +13,6 @@ UseTab: Never
 IndentWidth: 4
 BreakBeforeBraces: Linux
 AccessModifierOffset: -4
+ForEachMacros:
+  - 'for_each_set_bit'
+  - 'for_each_set_bit_from'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 obj-m += simplefs.o
-simplefs-objs := fs.o super.o inode.o file.o dir.o
+simplefs-objs := fs.o super.o inode.o file.o dir.o extent.o
 
 KDIR ?= /lib/modules/$(shell uname -r)/build
 

--- a/dir.c
+++ b/dir.c
@@ -38,7 +38,7 @@ static int simplefs_iterate(struct file *dir, struct dir_context *ctx)
         return 0;
 
     /* Read the directory index block on disk */
-    bh = sb_bread(sb, ci->index_block);
+    bh = sb_bread(sb, ci->dir_block);
     if (!bh)
         return -EIO;
     dblock = (struct simplefs_dir_block *) bh->b_data;

--- a/extent.c
+++ b/extent.c
@@ -1,0 +1,24 @@
+#include <linux/fs.h>
+#include <linux/kernel.h>
+
+#include "simplefs.h"
+
+/*
+ * Search the extent which contain the target block.
+ * Retrun the first unused file index if not found.
+ * Return -1 if it is out of range.
+ * TODO: use binary search.
+ */
+uint32_t simplefs_ext_search(struct simplefs_file_ei_block *index,
+                             uint32_t iblock)
+{
+    uint32_t i;
+    for (i = 0; i < SIMPLEFS_MAX_EXTENTS; i++) {
+        uint32_t block = index->extents[i].ee_block;
+        uint32_t len = index->extents[i].ee_len;
+        if (index->extents[i].ee_start == 0 ||
+            (iblock >= block && iblock < block + len))
+            return i;
+    }
+    return -1;
+}

--- a/mkfs.c
+++ b/mkfs.c
@@ -96,7 +96,7 @@ static int write_inode_store(int fd, struct superblock *sb)
     inode->i_ctime = inode->i_atime = inode->i_mtime = htole32(0);
     inode->i_blocks = htole32(1);
     inode->i_nlink = htole32(2);
-    inode->index_block = htole32(first_data_block);
+    inode->dir_block = htole32(first_data_block);
 
     int ret = write(fd, block, SIMPLEFS_BLOCK_SIZE);
     if (ret != SIMPLEFS_BLOCK_SIZE) {

--- a/script/test.sh
+++ b/script/test.sh
@@ -8,7 +8,7 @@ MKFS=$3
 D_MOD="drwxr-xr-x"
 F_MOD="-rw-r--r--"
 S_MOD="lrwxrwxrwx"
-MAXFILESIZE=4194304 # 4MiB
+MAXFILESIZE=11173888 # SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_BLOCKS_PER_EXTENT
 MAXFILES=128        # max files per dir
 
 test_op() {
@@ -41,7 +41,7 @@ sleep 1
 (modinfo $SIMPLEFS_MOD || exit 1) && \
 echo && \
 sudo insmod $SIMPLEFS_MOD  && \
-dd if=/dev/zero of=$IMAGE bs=1M count=$IMAGESIZE status=none&& \
+dd if=/dev/zero of=$IMAGE bs=1M count=$IMAGESIZE status=none && \
 ./$MKFS $IMAGE && \
 sudo mount -t simplefs -o loop $IMAGE test && \
 pushd test >/dev/null
@@ -82,7 +82,7 @@ test_op 'echo abc > file'
 test $(cat file) = "abc" || echo "Failed to write"
 
 # file too large
-test_op 'dd if=/dev/zero of=file bs=1M count=5 status=none'
+test_op 'dd if=/dev/zero of=file bs=1M count=12 status=none'
 filesize=$(sudo ls -lR  | grep -e "$F_MOD 2".*file | awk '{print $5}')
 test $filesize -le $MAXFILESIZE || echo "Failed, file size over the limit"
 

--- a/super.c
+++ b/super.c
@@ -74,7 +74,7 @@ static int simplefs_write_inode(struct inode *inode,
     disk_inode->i_mtime = inode->i_mtime.tv_sec;
     disk_inode->i_blocks = inode->i_blocks;
     disk_inode->i_nlink = inode->i_nlink;
-    disk_inode->index_block = ci->index_block;
+    disk_inode->ei_block = ci->ei_block;
     strncpy(disk_inode->i_data, ci->i_data, sizeof(ci->i_data));
 
     mark_buffer_dirty(bh);


### PR DESCRIPTION
Now the entry of index block of the file point to a extent which contain 8 consecutive physical blocks instead of a single block.

Also modify the block allocator so we can allocate consecutive blocks at once (also first fit).

Future work:
- A extent can contain up to `~(uint32_t) 0` blocks, so we may allocate more consecutive blocks for a extent with smarter block allocator and delayed allocation.
 - Use extent tree to increase extents a file can have.