### PR TITLE
Fix compilation warning because of type mismatch

### DIFF
--- a/file.c
+++ b/file.c
@@ -177,7 +177,7 @@ static int simplefs_write_end(struct file *file,
         /* Read ei_block to remove unused blocks */
         bh_index = sb_bread(sb, ci->ei_block);
         if (!bh_index) {
-            pr_err("failed truncating '%s'. we just lost %lu blocks\n",
+            pr_err("failed truncating '%s'. we just lost %llu blocks\n",
                    file->f_path.dentry->d_name.name,
                    nr_blocks_old - inode->i_blocks);
             goto end;


### PR DESCRIPTION
Because inode->i_blocks is 64 bytes unsigned integer, change
the format placeholder from %lu to %llu.

---
Details:
The `inode.i_blocks` is defined at [include/linux/fs.h](
https://github.com/torvalds/linux/blob/master/include/linux/fs.h#L654)

The type `blkcnt_t` is defined at [include/linux/types.h](
https://github.com/torvalds/linux/blob/master/include/linux/types.h#L126)