### PR TITLE
Simplify file block struct definition

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -480,7 +480,7 @@ static int simplefs_rename(struct inode *old_dir,
         goto relse_new;
     }
 
-    /* If new directory is empty, fail */
+    /* If new directory is full, fail */
     if (new_pos < 0) {
         ret = -EMLINK;
         goto relse_new;

--- a/simplefs.h
+++ b/simplefs.h
@@ -82,14 +82,12 @@ struct simplefs_inode_info {
     struct inode vfs_inode;
 };
 
-struct simplefs_extent {
-    uint32_t ee_block; /* first logical block extent covers */
-    uint32_t ee_len;   /* number of blocks covered by extent */
-    uint32_t ee_start; /* first physical block extent covers */
-};
-
 struct simplefs_file_ei_block {
-    struct simplefs_extent extents[SIMPLEFS_MAX_EXTENTS];
+    struct simplefs_extent {
+        uint32_t ee_block; /* first logical block extent covers */
+        uint32_t ee_len;   /* number of blocks covered by extent */
+        uint32_t ee_start; /* first physical block extent covers */
+    } extents[SIMPLEFS_MAX_EXTENTS];
 };
 
 struct simplefs_dir_block {


### PR DESCRIPTION
Instead of defining `simplefs_file_ei_block` and `simplefs_extent`
struct separately, define extent inside of file block could simplify
the code and keep the consistency of struct hierarchy between
`simplefs_file_ei_block` and `simplefs_dir_block`.

Besides, I think the word in comment of `inode.c` should be "full",
not "empty". Because if there's no inode available in new directory,
`new_pos` will stay negative after for loop. It means that the
new directory is full.