### PR TITLE
number of nr_free_blocks error

### DIFF
--- a/mkfs.c
+++ b/mkfs.c
@@ -39,7 +39,7 @@ static struct superblock *write_superblock(int fd, struct stat *fstats)
     uint32_t nr_ifree_blocks = idiv_ceil(nr_inodes, SIMPLEFS_BLOCK_SIZE * 8);
     uint32_t nr_bfree_blocks = idiv_ceil(nr_blocks, SIMPLEFS_BLOCK_SIZE * 8);
     uint32_t nr_data_blocks =
-        nr_blocks - 1 - nr_istore_blocks - nr_ifree_blocks - nr_bfree_blocks;
+        nr_blocks - nr_istore_blocks - nr_ifree_blocks - nr_bfree_blocks;
 
     memset(sb, 0, sizeof(struct superblock));
     sb->info = (struct simplefs_sb_info){


### PR DESCRIPTION
nr_free_blocks计算错误,nr_data_blocks初始化时已经-1 表示的是super block,然而在nr_free_blocks再次-1，导致实际空闲数量少一