### PR TITLE
Change parameter to initialize new inode in Linux 6.3

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -196,7 +196,7 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
 
     if (S_ISLNK(mode)) {
 #if MNT_IDMAP_REQUIRED()
-        inode_init_owner(&nop_mnt_idmap, inode, dir, inode->mode);
+        inode_init_owner(&nop_mnt_idmap, inode, dir, mode);
 #elif USER_NS_REQUIRED()
         inode_init_owner(&init_user_ns, inode, dir, mode);
 #else
@@ -219,7 +219,7 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
 
     /* Initialize inode */
 #if MNT_IDMAP_REQUIRED()
-    inode_init_owner(&nop_mnt_idmap, inode, dir, inode->mode);
+    inode_init_owner(&nop_mnt_idmap, inode, dir, mode);
 #elif USER_NS_REQUIRED()
     inode_init_owner(&init_user_ns, inode, dir, mode);
 #else

--- a/inode.c
+++ b/inode.c
@@ -195,7 +195,7 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
     }
 
     if (S_ISLNK(mode)) {
-#if USER_NS_REQUIRED_6_3()
+#if MNT_IDMAP_REQUIRED()
         inode_init_owner(&nop_mnt_idmap, inode, dir, inode->mode);
 #elif USER_NS_REQUIRED()
         inode_init_owner(&init_user_ns, inode, dir, mode);
@@ -218,7 +218,7 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
     }
 
     /* Initialize inode */
-#if USER_NS_REQUIRED_6_3()
+#if MNT_IDMAP_REQUIRED()
     inode_init_owner(&nop_mnt_idmap, inode, dir, inode->mode);
 #elif USER_NS_REQUIRED()
     inode_init_owner(&init_user_ns, inode, dir, mode);
@@ -258,7 +258,7 @@ put_ino:
  *   - cleanup index block of the new inode
  *   - add new file/directory in parent index
  */
-#if USER_NS_REQUIRED_6_3()
+#if MNT_IDMAP_REQUIRED()
 static int simplefs_create(struct mnt_idmap *id,
                            struct inode *dir,
                            struct dentry *dentry,
@@ -565,7 +565,7 @@ clean_inode:
     return ret;
 }
 
-#if USER_NS_REQUIRED_6_3()
+#if MNT_IDMAP_REQUIRED()
 static int simplefs_rename(struct mnt_idmap *id,
                            struct inode *old_dir,
                            struct dentry *old_dentry,
@@ -716,7 +716,7 @@ release_new:
     return ret;
 }
 
-#if USER_NS_REQUIRED_6_3()
+#if MNT_IDMAP_REQUIRED()
 static int simplefs_mkdir(struct mnt_idmap *id,
                           struct inode *dir,
                           struct dentry *dentry,
@@ -840,7 +840,7 @@ end:
     return ret;
 }
 
-#if USER_NS_REQUIRED_6_3()
+#if MNT_IDMAP_REQUIRED()
 static int simplefs_symlink(struct mnt_idmap *id,
                             struct inode *dir,
                             struct dentry *dentry,

--- a/inode.c
+++ b/inode.c
@@ -195,7 +195,9 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
     }
 
     if (S_ISLNK(mode)) {
-#if USER_NS_REQUIRED()
+#if USER_NS_REQUIRED_6_3()
+        inode_init_owner(&nop_mnt_idmap, inode, dir, inode->mode);
+#elif USER_NS_REQUIRED()
         inode_init_owner(&init_user_ns, inode, dir, mode);
 #else
         inode_init_owner(inode, dir, mode);
@@ -216,7 +218,9 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
     }
 
     /* Initialize inode */
-#if USER_NS_REQUIRED()
+#if USER_NS_REQUIRED_6_3()
+    inode_init_owner(&nop_mnt_idmap, inode, dir, inode->mode);
+#elif USER_NS_REQUIRED()
     inode_init_owner(&init_user_ns, inode, dir, mode);
 #else
     inode_init_owner(inode, dir, mode);
@@ -254,7 +258,13 @@ put_ino:
  *   - cleanup index block of the new inode
  *   - add new file/directory in parent index
  */
-#if USER_NS_REQUIRED()
+#if USER_NS_REQUIRED_6_3()
+static int simplefs_create(struct mnt_idmap *id,
+                           struct inode *dir,
+                           struct dentry *dentry,
+                           umode_t mode,
+                           bool excl)
+#elif USER_NS_REQUIRED()
 static int simplefs_create(struct user_namespace *ns,
                            struct inode *dir,
                            struct dentry *dentry,
@@ -555,7 +565,14 @@ clean_inode:
     return ret;
 }
 
-#if USER_NS_REQUIRED()
+#if USER_NS_REQUIRED_6_3()
+static int simplefs_rename(struct mnt_idmap *id,
+                           struct inode *old_dir,
+                           struct dentry *old_dentry,
+                           struct inode *new_dir,
+                           struct dentry *new_dentry,
+                           unsigned int flags)
+#elif USER_NS_REQUIRED()
 static int simplefs_rename(struct user_namespace *ns,
                            struct inode *old_dir,
                            struct dentry *old_dentry,
@@ -699,7 +716,15 @@ release_new:
     return ret;
 }
 
-#if USER_NS_REQUIRED()
+#if USER_NS_REQUIRED_6_3()
+static int simplefs_mkdir(struct mnt_idmap *id,
+                          struct inode *dir,
+                          struct dentry *dentry,
+                          umode_t mode)
+{
+    return simplefs_create(id, dir, dentry, mode | S_IFDIR, 0);
+}
+#elif USER_NS_REQUIRED()
 static int simplefs_mkdir(struct user_namespace *ns,
                           struct inode *dir,
                           struct dentry *dentry,
@@ -815,7 +840,12 @@ end:
     return ret;
 }
 
-#if USER_NS_REQUIRED()
+#if USER_NS_REQUIRED_6_3()
+static int simplefs_symlink(struct mnt_idmap *id,
+                            struct inode *dir,
+                            struct dentry *dentry,
+                            const char *symname)
+#elif USER_NS_REQUIRED()
 static int simplefs_symlink(struct user_namespace *ns,
                             struct inode *dir,
                             struct dentry *dentry,

--- a/simplefs.h
+++ b/simplefs.h
@@ -27,6 +27,7 @@
 #include <linux/version.h>
 
 #define USER_NS_REQUIRED() LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
+#define USER_NS_REQUIRED_6_3() LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
 
 /*
  * simplefs partition layout

--- a/simplefs.h
+++ b/simplefs.h
@@ -27,7 +27,7 @@
 #include <linux/version.h>
 
 #define USER_NS_REQUIRED() LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
-#define USER_NS_REQUIRED_6_3() LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
+#define MNT_IDMAP_REQUIRED() LINUX_VERSION_CODE >= KERNEL_VERSION(6,3,0)
 
 /*
  * simplefs partition layout

--- a/super.c
+++ b/super.c
@@ -282,7 +282,10 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent)
         ret = PTR_ERR(root_inode);
         goto free_bfree;
     }
-#if USER_NS_REQUIRED()
+
+#if USER_NS_REQUIRED_6_3()
+    inode_init_owner(&nop_mnt_idmap, root_inode, NULL, root_inode->i_mode);
+#elif USER_NS_REQUIRED()
     inode_init_owner(&init_user_ns, root_inode, NULL, root_inode->i_mode);
 #else
     inode_init_owner(root_inode, NULL, root_inode->i_mode);

--- a/super.c
+++ b/super.c
@@ -283,7 +283,7 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent)
         goto free_bfree;
     }
 
-#if USER_NS_REQUIRED_6_3()
+#if MNT_IDMAP_REQUIRED()
     inode_init_owner(&nop_mnt_idmap, root_inode, NULL, root_inode->i_mode);
 #elif USER_NS_REQUIRED()
     inode_init_owner(&init_user_ns, root_inode, NULL, root_inode->i_mode);


### PR DESCRIPTION
Change the parameter to initialize new inode in creating new file system, and thanks to [@cbkadal](https://github.com/cbkadal) for reporting [Issue#25](https://github.com/sysprog21/simplefs/issues).