### PR TITLE
Change parameter to initialize new inode in Linux 6.3

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -196,7 +196,7 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
 
     if (S_ISLNK(mode)) {
 #if MNT_IDMAP_REQUIRED()
-        inode_init_owner(&nop_mnt_idmap, inode, dir, inode->mode);
+        inode_init_owner(&nop_mnt_idmap, inode, dir, mode);
 #elif USER_NS_REQUIRED()
         inode_init_owner(&init_user_ns, inode, dir, mode);
 #else
@@ -219,7 +219,7 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
 
     /* Initialize inode */
 #if MNT_IDMAP_REQUIRED()
-    inode_init_owner(&nop_mnt_idmap, inode, dir, inode->mode);
+    inode_init_owner(&nop_mnt_idmap, inode, dir, mode);
 #elif USER_NS_REQUIRED()
     inode_init_owner(&init_user_ns, inode, dir, mode);
 #else


### PR DESCRIPTION
Change the parameter to initialize new inode in creating new file system, and thanks to [@cbkadal](https://github.com/cbkadal) for reporting [Issue#25](https://github.com/sysprog21/simplefs/issues).