### PR TITLE
Fix fs not showing current and parent directories

### DIFF
--- a/mkfs.c
+++ b/mkfs.c
@@ -90,6 +90,12 @@ static int write_inode_store(int fd, struct superblock *sb)
     uint32_t first_data_block = 1 + le32toh(sb->info.nr_bfree_blocks) +
                                 le32toh(sb->info.nr_ifree_blocks) +
                                 le32toh(sb->info.nr_istore_blocks);
+    /*
+     * Use inode 1 for root.
+     * If system use glibc, readdir will skip inode 0, and vfs also avoid
+     * using inode 0
+     */
+    inode += 1;
     inode->i_mode = htole32(S_IFDIR | S_IRUSR | S_IRGRP | S_IROTH | S_IWUSR |
                             S_IWGRP | S_IXUSR | S_IXGRP | S_IXOTH);
     inode->i_uid = 0;
@@ -140,7 +146,7 @@ static int write_ifree_blocks(int fd, struct superblock *sb)
     memset(ifree, 0xff, SIMPLEFS_BLOCK_SIZE);
 
     /* First ifree block, containing first used inode */
-    ifree[0] = htole64(0xfffffffffffffffe);
+    ifree[0] = htole64(0xfffffffffffffffc);
     int ret = write(fd, ifree, SIMPLEFS_BLOCK_SIZE);
     if (ret != SIMPLEFS_BLOCK_SIZE) {
         ret = -1;

--- a/super.c
+++ b/super.c
@@ -277,7 +277,7 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent)
     }
 
     /* Create root inode */
-    root_inode = simplefs_iget(sb, 0);
+    root_inode = simplefs_iget(sb, 1);
     if (IS_ERR(root_inode)) {
         ret = PTR_ERR(root_inode);
         goto free_bfree;


### PR DESCRIPTION
Description:
In previous linux kernel version (e.g 5.8), ls -la will not show .
and .. in root directory

Root cause :
In Linux system, there are different way to implement "ls" command.
Like Ubuntu system, using glibc. Embedded system using busybox.
glibc/ busybox code show in reference

And you can see that the ext2/ ext3/ ext4/ system all skip inode
number 0. In kernel document ext4 also say that "There is no inode 0"

In "patchwork - vfs: avoid creation of inode number 0 in get_next_ino"
add code to avoid to provide the 0 inode so in 6.3 kernel source code,
we can see these patch code

Fix solution:
By following ext4 rule, skip inode number 0. When creating image
layout in inode section, we skip first block and use next inode (inode
number 1) with the root inode. And we also modify the d_make_root, we
use inode number 1 for the root inode.

How has this been tested:
In kernel 5.15 here is original source code:
    ubuntu@primary:/home/roy/src-code/github/roy/simplefs/test15$ uname -a
    Linux primary 5.15.0-73-generic #80-Ubuntu SMP Mon May 15 15:18:26 UTC
    2023 x86_64 x86_64 x86_64 GNU/Linux
    ubuntu@primary:/home/roy/src-code/github/roy/simplefs/test15$ ls -la
    total 0
In kernel 5.15 here is patch code
    ubuntu@primary:/home/roy/src-code/github/roy/simplefs/test15$ uname -a
    Linux primary 5.15.0-73-generic #80-Ubuntu SMP Mon May 15 15:18:26 UTC
    2023 x86_64 x86_64 x86_64 GNU/Linux
    ubuntu@primary:/home/roy/src-code/github/roy/simplefs/test15$ ls -la
    total 5
    drwxrwxr-x 2 root   root   4096 Jan  1  1970 .
    drwxrwxr-x 1 ubuntu ubuntu 4096 Jul 22 22:10 ..
In kernel 5.4 here is original source code:
    ubuntu@vcluster101-vxm:/home/roy/src-code/github/roy/simplefs$ uname -a
    Linux vcluster101-vxm 5.4.0-153-generic #170-Ubuntu SMP Fri Jun 16 13:43:31
    UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
    ubuntu@vcluster101-vxm:/home/roy/src-code/github/roy/simplefs/test4$ ls -la
    total 0
In kernel 5.4 here is patch code
    ubuntu@vcluster101-vxm:/home/roy/src-code/github/roy/simplefs/test4$ uname -a
    Linux vcluster101-vxm 5.4.0-153-generic #170-Ubuntu SMP Fri Jun 16 13:43:31
    UTC 2023 x86_64 x86_64 x86_64 GNU/Linux
    ubuntu@vcluster101-vxm:/home/roy/src-code/github/roy/simplefs/test4$ ls -la
    total 5
    drwxrwxr-x 2 root   root   4096 Jan  1  1970 .
    drwxrwxr-x 1 ubuntu ubuntu 4096 Jul 22 22:42 ..

references:
Glibc may have a patch to fix readdir?, 
https://sourceware.org/bugzilla/show_bug.cgi?id=19970

glibc implement readdir, 
https://elixir.bootlin.com/glibc/glibc-2.35.9000/source/sysdeps/unix/sysv/linux/readdir64.c#L31

busybox implement ls, 
https://github.com/mirror/busybox/blob/2d4a3d9e6c1493a9520b907e07a41aca90cdfd94/coreutils/ls.c#L924

ext2, ext3 ,ext4 file system don't use 0 for root inode, 
https://stackoverflow.com/questions/2099121/why-do-inode-numbers-start-from-1-and-not-0

Linux kernel document in ext4 file system, 
https://www.kernel.org/doc/html/latest/filesystems/ext4/inodes.html?highlight=inode

vfs: avoid inode 0, 
https://patchwork.kernel.org/project/linux-fsdevel/patch/1435245958-4507-1-git-send-email-cmaiolino@redhat.com/

Linux kernel in inode, 6.3 
https://elixir.bootlin.com/linux/v6.3.13/source/fs/inode.c#L983

Close #12