### PR TITLE
access inode's ctime access using proper accessors

### DIFF
--- a/super.c
+++ b/super.c
@@ -69,7 +69,15 @@ static int simplefs_write_inode(struct inode *inode,
     disk_inode->i_uid = i_uid_read(inode);
     disk_inode->i_gid = i_gid_read(inode);
     disk_inode->i_size = inode->i_size;
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+    struct timespec64 ctime = inode_get_ctime(inode);
+    disk_inode->i_ctime = ctime.tv_sec;
+#else
     disk_inode->i_ctime = inode->i_ctime.tv_sec;
+#endif
+
+
     disk_inode->i_atime = inode->i_atime.tv_sec;
     disk_inode->i_mtime = inode->i_mtime.tv_sec;
     disk_inode->i_blocks = inode->i_blocks;


### PR DESCRIPTION
commit: 9b6304c1d53745c300b86f202d0dcff395e2d2db introduces new accessors to prevent raw r/w to inode's ctime. this patch moves that access to the new infrastructure