### PR TITLE
inode_set_ctime and inode_set_ctime_to_ts are not present on kernel 6…

### DIFF
--- a/file.c
+++ b/file.c
@@ -185,7 +185,7 @@ static int simplefs_write_end(struct file *file,
     /* Update inode metadata */
     inode->i_blocks = inode->i_size / SIMPLEFS_BLOCK_SIZE + 2;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     cur_time = current_time(inode);
     inode->i_mtime = cur_time;
     inode_set_ctime_to_ts(inode, cur_time);

--- a/inode.c
+++ b/inode.c
@@ -55,7 +55,7 @@ struct inode *simplefs_iget(struct super_block *sb, unsigned long ino)
     i_gid_write(inode, le32_to_cpu(cinode->i_gid));
     inode->i_size = le32_to_cpu(cinode->i_size);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     inode_set_ctime(inode, (time64_t) le32_to_cpu(cinode->i_ctime), 0);
 #else
     inode->i_ctime.tv_sec = (time64_t) le32_to_cpu(cinode->i_ctime);
@@ -214,7 +214,7 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
 #endif
         set_nlink(inode, 1);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
         cur_time = current_time(inode);
         inode->i_atime = inode->i_mtime = cur_time;
         inode_set_ctime_to_ts(inode, cur_time);
@@ -256,7 +256,7 @@ static struct inode *simplefs_new_inode(struct inode *dir, mode_t mode)
         set_nlink(inode, 1);
     }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     cur_time = current_time(inode);
     inode->i_atime = inode->i_mtime = cur_time;
     inode_set_ctime_to_ts(inode, cur_time);
@@ -394,7 +394,7 @@ static int simplefs_create(struct inode *dir,
     /* Update stats and mark dir and new inode dirty */
     mark_inode_dirty(inode);
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     cur_time = current_time(dir);
     dir->i_mtime = dir->i_atime = cur_time;
     inode_set_ctime_to_ts(dir, cur_time);
@@ -533,7 +533,7 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
         goto clean_inode;
 
     /* Update inode stats */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     cur_time = current_time(dir);
     dir->i_mtime = dir->i_atime = cur_time;
     inode_set_ctime_to_ts(dir, cur_time);
@@ -601,7 +601,7 @@ clean_inode:
     i_gid_write(inode, 0);
     inode->i_mode = 0;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     inode->i_mtime.tv_sec = inode->i_atime.tv_sec = 0;
     inode_set_ctime(inode, 0, 0);
 #else
@@ -743,7 +743,7 @@ static int simplefs_rename(struct inode *old_dir,
     brelse(bh2);
 
     /* Update new parent inode metadata */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     cur_time = current_time(new_dir);
     new_dir->i_atime = new_dir->i_mtime = cur_time;
     inode_set_ctime_to_ts(new_dir, cur_time);
@@ -761,7 +761,7 @@ static int simplefs_rename(struct inode *old_dir,
         goto release_new;
 
     /* Update old parent inode metadata */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     cur_time = current_time(old_dir);
     old_dir->i_atime = old_dir->i_mtime = cur_time;
     inode_set_ctime_to_ts(old_dir, cur_time);

--- a/super.c
+++ b/super.c
@@ -70,7 +70,7 @@ static int simplefs_write_inode(struct inode *inode,
     disk_inode->i_gid = i_gid_read(inode);
     disk_inode->i_size = inode->i_size;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 6, 0)
     struct timespec64 ctime = inode_get_ctime(inode);
     disk_inode->i_ctime = ctime.tv_sec;
 #else


### PR DESCRIPTION
inode_set_ctime_to_ts and inode_set_ctime start from kernel 6.6 and are not present in kernel 6.5