### PR TITLE
Fix rm hard link bug

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -897,6 +897,7 @@ static int simplefs_link(struct dentry *old_dentry,
     brelse(bh);
 
     inode_inc_link_count(inode);
+    ihold(inode);
     d_instantiate(dentry, inode);
     return ret;
 

--- a/inode.c
+++ b/inode.c
@@ -472,7 +472,8 @@ static int simplefs_remove_from_dir(struct inode *dir, struct dentry *dentry)
             }
             /* Remove file from parent directory */
             for (fi = 0; fi < SIMPLEFS_FILES_PER_BLOCK; fi++) {
-                if (dblock->files[fi].inode == inode->i_ino) {
+                if (dblock->files[fi].inode == inode->i_ino &&
+                    !strcmp(dblock->files[fi].filename, dentry->d_name.name) ) {
                     found = true;
                     if (fi != SIMPLEFS_FILES_PER_BLOCK - 1) {
                         memmove(dblock->files + fi, dblock->files + fi + 1,


### PR DESCRIPTION
Description
-----------
When create a hard link and then remove this hard link, at this time we use "ls" to list all files, the file lists will not correct showing the result

here is showing result:

.:
ls: cannot access 'hdlink': No such file or directory total 1
-rw-r--r-- 1 root root 0 Feb 19 03:32 file2
?????????? ? ?    ?    ?            ? hdlink

this means the rm hard link remove the original file, not remove hard link file

Root cause
----------
In unlink function, we not only need to check ino number is the same, but also check the the inode block name is the same

Fix solution
----------
Add to check the find block's name is the same with remove name

How has this been tested:
----------
run: touch file1
run: touch file2
run:ln file1 hdlink
run:ls -lR
.:
total 2
-rw-r--r-- 2 root root 0 Feb 19 15:00 file1
-rw-r--r-- 1 root root 0 Feb 19 15:00 file2
-rw-r--r-- 2 root root 0 Feb 19 15:00 hdlink
run:rm hdlink
run:ls -lR
.:
total 1
-rw-r--r-- 1 root root 0 Feb 19 15:00 file1
-rw-r--r-- 1 root root 0 Feb 19 15:00 file2