### PR TITLE
Fix errors raised by missing-prototypes

### DIFF
--- a/extent.c
+++ b/extent.c
@@ -6,19 +6,69 @@
 /* Search for the extent containing the target block.
  * Returns the first unused file index if not found.
  * Returns -1 if the target block is out of range.
- * TODO: Implement binary search for efficiency.
+ * Binary search is used for efficiency.
  */
 uint32_t simplefs_ext_search(struct simplefs_file_ei_block *index,
                              uint32_t iblock)
 {
-    uint32_t i;
-    for (i = 0; i < SIMPLEFS_MAX_EXTENTS; i++) {
-        uint32_t block = index->extents[i].ee_block;
-        uint32_t len = index->extents[i].ee_len;
-        if (index->extents[i].ee_start == 0 ||
-            (iblock >= block && iblock < block + len))
-            return i;
+    /* first, find the first unused file index with binary search.
+     * It'll be our right boundary for actual binary search
+     * and return value when file index is not found.
+     */
+    uint32_t start = 0;
+    uint32_t end = SIMPLEFS_MAX_EXTENTS - 1;
+    uint32_t boundary;
+    uint32_t end_block;
+    uint32_t end_len;
+
+    while (start < end) {
+        uint32_t mid = start + (end - start) / 2;
+        if (index->extents[mid].ee_start == 0) {
+            end = mid;
+        } else {
+            start = mid + 1;
+        }
     }
 
-    return -1;
+    if (index->extents[end].ee_start == 0) {
+        boundary = end;
+    } else {
+        /* File index full */
+        boundary = end + 1;
+    }
+
+    if (boundary == 0) {
+        /* No used file index */
+        return boundary;
+    }
+
+    /* try finding target block using binary search */
+    start = 0;
+    end = boundary - 1;
+    while (start < end) {
+        uint32_t mid = start + (end - start) / 2;
+        uint32_t block = index->extents[mid].ee_block;
+        uint32_t len = index->extents[mid].ee_len;
+        if (iblock >= block && iblock < block + len) {
+            /* found before search finished */
+            return mid;
+        }
+        if (iblock < block) {
+            end = mid;
+        } else {
+            start = mid + 1;
+        }
+    }
+
+    /* return 'end' if it directs to valid block
+     * return 'boundary' if index is not found
+     * and eiblock has remaining space */
+    end_block = index->extents[end].ee_block;
+    end_len = index->extents[end].ee_len;
+    if (iblock >= end_block && iblock < end_len) {
+        return end;
+    } else if (boundary < SIMPLEFS_MAX_EXTENTS) {
+        return boundary;
+    }
+    return boundary;
 }

--- a/simplefs.h
+++ b/simplefs.h
@@ -123,7 +123,7 @@ extern const struct address_space_operations simplefs_aops;
 extern uint32_t simplefs_ext_search(struct simplefs_file_ei_block *index,
                                     uint32_t iblock);
 
-/* Getters for superbock and inode */
+/* Getters for superblock and inode */
 #define SIMPLEFS_SB(sb) (sb->s_fs_info)
 #define SIMPLEFS_INODE(inode) \
     (container_of(inode, struct simplefs_inode_info, vfs_inode))

--- a/simplefs.h
+++ b/simplefs.h
@@ -108,11 +108,18 @@ struct simplefs_dir_block {
 
 /* superblock functions */
 int simplefs_fill_super(struct super_block *sb, void *data, int silent);
+void simplefs_kill_sb(struct super_block *sb);
 
 /* inode functions */
 int simplefs_init_inode_cache(void);
 void simplefs_destroy_inode_cache(void);
 struct inode *simplefs_iget(struct super_block *sb, unsigned long ino);
+
+/* dentry function */
+struct dentry *simplefs_mount(struct file_system_type *fs_type,
+                              int flags,
+                              const char *dev_name,
+                              void *data);
 
 /* file functions */
 extern const struct file_operations simplefs_file_ops;


### PR DESCRIPTION
In the current attempt to run simplefs on the Linux kernel v6.8 environment, encountering the error "no previous prototype for `simplefs_mount`" indicates a need for additional function declarations. 
```
error: no previous prototype for ‘simplefs_mount’
error: no previous prototype for ‘simplefs_kill_sb’ 
```
The reason why it worked in previous versions is that the changes related to `-Wmissing-declarations` and `-Wmissing-prototypes` were introduced in 6.8-rc1 in [commit 0fcb708](https://github.com/torvalds/linux/commit/0fcb70851fbfea1776ae62f67c503fef8f0292b9) .