### PR TITLE
Fix errors raised by missing-prototypes

### DIFF
--- a/simplefs.h
+++ b/simplefs.h
@@ -108,11 +108,18 @@ struct simplefs_dir_block {
 
 /* superblock functions */
 int simplefs_fill_super(struct super_block *sb, void *data, int silent);
+void simplefs_kill_sb(struct super_block *sb);
 
 /* inode functions */
 int simplefs_init_inode_cache(void);
 void simplefs_destroy_inode_cache(void);
 struct inode *simplefs_iget(struct super_block *sb, unsigned long ino);
+
+/* dentry function */
+struct dentry *simplefs_mount(struct file_system_type *fs_type,
+                              int flags,
+                              const char *dev_name,
+                              void *data);
 
 /* file functions */
 extern const struct file_operations simplefs_file_ops;


### PR DESCRIPTION
In the current attempt to run simplefs on the Linux kernel v6.8 environment, encountering the error "no previous prototype for `simplefs_mount`" indicates a need for additional function declarations. 
```
error: no previous prototype for ‘simplefs_mount’
error: no previous prototype for ‘simplefs_kill_sb’ 
```
The reason why it worked in previous versions is that the changes related to `-Wmissing-declarations` and `-Wmissing-prototypes` were introduced in 6.8-rc1 in [commit 0fcb708](https://github.com/torvalds/linux/commit/0fcb70851fbfea1776ae62f67c503fef8f0292b9) .