### PR TITLE
Fix sb_read and umount cache not be freed

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -60,9 +60,11 @@ static int simplefs_iterate(struct file *dir, struct dir_context *ctx)
                 goto release_bh;
             }
             dblock = (struct simplefs_dir_block *) bh2->b_data;
-            if (dblock->files[0].inode == 0)
+            if (dblock->files[0].inode == 0) {
+                brelse(bh2);
+                bh2 = NULL;
                 break;
-
+            }
             /* Iterate every file in one block */
             for (; fi < SIMPLEFS_FILES_PER_BLOCK; fi++) {
                 f = &dblock->files[fi];

--- a/fs.c
+++ b/fs.c
@@ -58,6 +58,8 @@ static int __init simplefs_init(void)
 
 err_inode:
     simplefs_destroy_inode_cache();
+    /* Only after rcu_barrier() is the memory guaranteed to be freed. */
+    rcu_barrier();
 err:
     return ret;
 }
@@ -69,6 +71,8 @@ static void __exit simplefs_exit(void)
         pr_err("Failed to unregister file system\n");
 
     simplefs_destroy_inode_cache();
+    /* Only after rcu_barrier() is the memory guaranteed to be freed. */
+    rcu_barrier();
 
     pr_info("module unloaded\n");
 }

--- a/inode.c
+++ b/inode.c
@@ -749,8 +749,8 @@ static int simplefs_rename(struct inode *old_dir,
                     break;
                 }
             }
-            if (new_pos < 0)
-                brelse(bh2);
+
+            brelse(bh2);
         }
     }
 

--- a/super.c
+++ b/super.c
@@ -37,6 +37,9 @@ int simplefs_init_inode_cache(void)
 /* De-allocate the inode cache */
 void simplefs_destroy_inode_cache(void)
 {
+    /* wait for call_rcu() and prevent the free cache be used */
+    rcu_barrier();
+
     kmem_cache_destroy(simplefs_inode_cache);
 }
 


### PR DESCRIPTION
Using kmemleak to detect the leak, I found the the command "ls" and "mv" will make the cache leak

here are the leak informations:

	0 [<ffffffffa5d2f98e>] __alloc_pages+0x24e
	1 [<ffffffffa5d2f98e>] __alloc_pages+0x24e
	2 [<ffffffffa5d51d3e>] alloc_pages+0x9e
	3 [<ffffffffa5cbd4de>] __page_cache_alloc+0x7e
	4 [<ffffffffa5cc1342>] pagecache_get_page+0x152
	5 [<ffffffffa5dedec8>] grow_dev_page+0x48
	6 [<ffffffffa5deebac>] __getblk_gfp+0xbc
	7 [<ffffffffa5deed01>] __bread_gfp+0x11
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ <-- seems __bread() leak.
	8 [<ffffffffc098427b>] ftrace_trampoline+0x427b
	9 [<ffffffffc09845a7>] ftrace_trampoline+0x45a7
	10 [<ffffffffa5dafaed>] vfs_mkdir+0xad
	11 [<ffffffffa5db3368>] do_mkdirat+0x128
	12 [<ffffffffa5db351c>] __x64_sys_mkdir+0x4c
	13 [<ffffffffa5a04d64>] x64_sys_call+0x94
	14 [<ffffffffa67c2ce6>] do_syscall_64+0x56
	15 [<ffffffffa68000df>] entry_SYSCALL_64_after_hwframe+0x67

