### PR TITLE
Implement mounting and unmounting for external journal device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ all: $(MKFS)
 
 IMAGE ?= test.img
 IMAGESIZE ?= 200
+JOURNAL ?= journal.img
+JOURNALSIZE ?= 8
+
 # To test max files(40920) in directory, the image size should be at least 159.85 MiB
 # 40920 * 4096(block size) ~= 159.85 MiB
 
@@ -20,12 +23,18 @@ $(IMAGE): $(MKFS)
 	dd if=/dev/zero of=${IMAGE} bs=1M count=${IMAGESIZE}
 	./$< $(IMAGE)
 
+journal: $(JOURNAL)
+
+$(JOURNAL):
+	dd if=/dev/zero of=$(JOURNAL) bs=1M count=$(JOURNALSIZE)
+	mke2fs -b 4096 -O journal_dev $(JOURNAL)
+
 check: all
 	script/test.sh $(IMAGE) $(IMAGESIZE) $(MKFS)
 
 clean:
 	make -C $(KDIR) M=$(PWD) clean
 	rm -f *~ $(PWD)/*.ur-safe
-	rm -f $(MKFS) $(IMAGE)
+	rm -f $(MKFS) $(IMAGE) $(JOURNAL)
 
-.PHONY: all clean
+.PHONY: all clean journal

--- a/simplefs.h
+++ b/simplefs.h
@@ -39,6 +39,9 @@
  * |      blocks   |  rest of the blocks
  * +---------------+
  */
+#ifdef __KERNEL__
+#include <linux/jbd2.h>
+#endif
 
 struct simplefs_inode {
     uint32_t i_mode;   /* File mode */
@@ -71,6 +74,10 @@ struct simplefs_sb_info {
     uint32_t nr_free_blocks; /* Number of free blocks */
 
 #ifdef __KERNEL__
+    journal_t *journal;
+    struct block_device *s_journal_bdev; /* v5.10+ external journal device */
+    struct bdev_handle
+        *s_journal_bdev_handle;  /* v6.7+ external journal device */
     unsigned long *ifree_bitmap; /* In-memory free inodes bitmap */
     unsigned long *bfree_bitmap; /* In-memory free blocks bitmap */
 #endif


### PR DESCRIPTION
This pull request continues from https://github.com/sysprog21/simplefs/pull/59#issue-2363416768. 
Due to some issues with Git, I have addressed them and created this new pull request.


Added a function simplefs_parse_options in the fill super process to obtain the external journal device and configure it using jbd2 related functions. Additionally, journal-related functionality was added to the write functions to record metadata "extent" information.

Also, added a "make journal" command in the Makefile, allowing users to create an external journal device image and mount it to simplefs.