### PR TITLE
Reimplement the read and the write operations

### DIFF
--- a/simplefs.h
+++ b/simplefs.h
@@ -10,6 +10,8 @@
 #define SIMPLEFS_MAX_EXTENTS \
     ((SIMPLEFS_BLOCK_SIZE - sizeof(uint32_t)) / sizeof(struct simplefs_extent))
 #define SIMPLEFS_MAX_BLOCKS_PER_EXTENT 8 /* It can be ~(uint32) 0 */
+#define SIMPLEFS_MAX_SIZES_PER_EXTENT \
+    (SIMPLEFS_MAX_BLOCKS_PER_EXTENT * SIMPLEFS_BLOCK_SIZE)
 #define SIMPLEFS_MAX_FILESIZE                                          \
     ((uint64_t) SIMPLEFS_MAX_BLOCKS_PER_EXTENT * SIMPLEFS_BLOCK_SIZE * \
      SIMPLEFS_MAX_EXTENTS)


### PR DESCRIPTION
problem:
Currently, simplefs does not implement read and write operations and therefore uses the default implementation provided by the Linux kernel. Unfortunately, this implementation assumes that the data blocks are filled contiguously, which leads to potential performance and usability problems.

Implemented simplefs_file_read:
 - Reads data from the file based on the specified position and length.
 - Ensures that data is read only within the file size limits.
 - Directly reads data from the disk through extent blocks.

Implemented simplefs_file_write:
 - Writes data to the file starting from the specified position.
 - Allocates new blocks if necessary, managing extent-based allocation.
 - Updates inode size and block count correctly after writing.
 - Ensures data is written within the file system's maximum file size limit.
 - Directly writes data to the disk through extent blocks.

Both functions include proper error handling, resource management, and synchronization to ensure data store in disk.

Close #57