### PR TITLE
Fix symlink block allocation mismatch causing unlink bitmap errors

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -653,8 +653,6 @@ clean_inode:
 #endif
 
     inode_dec_link_count(inode);
-    drop_nlink(inode);
-    mark_inode_dirty(inode);
 
     /* Free inode and index block from bitmap */
     if (!S_ISLNK(inode->i_mode))

--- a/inode.c
+++ b/inode.c
@@ -640,7 +640,6 @@ clean_inode:
     inode->i_size = 0;
     i_uid_write(inode, 0);
     i_gid_write(inode, 0);
-    inode->i_mode = 0;
 
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
     inode_set_mtime(inode, 0, 0);
@@ -658,7 +657,9 @@ clean_inode:
     mark_inode_dirty(inode);
 
     /* Free inode and index block from bitmap */
-    put_blocks(sbi, bno, 1);
+    if (!S_ISLNK(inode->i_mode))
+        put_blocks(sbi, bno, 1);
+    inode->i_mode = 0;
     put_inode(sbi, ino);
 
     return ret;

--- a/script/test.sh
+++ b/script/test.sh
@@ -13,7 +13,7 @@ MAXFILES=40920        # max files per dir
 MOUNT_TEST=100
 
 test_op() {
-    local op=$1 
+    local op=$1
     echo
     echo -n "Testing cmd: $op..."
     sudo sh -c "$op" >/dev/null && echo "Success"
@@ -26,7 +26,7 @@ check_exist() {
     echo
     echo -n "Check if exist: $mode $nlink $name..."
     sudo ls -lR  | grep -e "$mode $nlink".*$name >/dev/null && echo "Success" || \
-    echo "Failed" 
+    echo "Failed"
 }
 
 if [ "$EUID" -eq 0 ]
@@ -34,7 +34,7 @@ if [ "$EUID" -eq 0 ]
   exit
 fi
 
-mkdir -p test  
+mkdir -p test
 sudo umount test 2>/dev/null
 sleep 1
 sudo rmmod simplefs 2>/dev/null
@@ -123,12 +123,22 @@ test_op 'dd if=/dev/zero of=file bs=1M count=12 status=none'
 filesize=$(sudo ls -lR  | grep -e "$F_MOD 2".*file | awk '{print $5}')
 test $filesize -le $MAXFILESIZE || echo "Failed, file size over the limit"
 
+# test remove symbolic link
+test_op 'ln -s file symlink_fake'
+test_op 'rm -f symlink_fake'
+test_op 'touch symlink_fake'
+test_op 'ln file symlink_hard_fake'
+test_op 'rm -f symlink_hard_fake'
+test_op 'touch symlink_hard_fake'
+
 # test if exist
-check_exist $D_MOD 3 dir 
+check_exist $D_MOD 3 dir
 check_exist $F_MOD 2 file
 check_exist $F_MOD 2 hdlink
 check_exist $D_MOD 2 dir
-check_exist $S_MOD 1 symlink 
+check_exist $S_MOD 1 symlink
+check_exist $F_MOD 1 symlink_fake
+check_exist $F_MOD 1 symlink_hard_fake
 
 sleep 1
 popd >/dev/null


### PR DESCRIPTION
When we create symbolic link, in simplefs_new_inode function, the symbolic
does not use ei_block to record the using block. But in simplefs_unlink function we use the ei_block to clean the bitmap, this makes the unlink will clean the "0" bit in bitmap.

Close #58

Also fixing the warning messages.
```
[13519.467953] ------------[ cut here ]------------
[13519.467954] WARNING: CPU: 1 PID: 287149 at fs/inode.c:307 drop_nlink+0x2c/0x40
....
[13519.468072]  ? drop_nlink+0x2c/0x40
[13519.468074]  ? __warn+0x8c/0x100
[13519.468077]  ? drop_nlink+0x2c/0x40
[13519.468080]  ? report_bug+0xa4/0xd0
[13519.468083]  ? handle_bug+0x39/0x90
[13519.468086]  ? exc_invalid_op+0x19/0x70
[13519.468089]  ? asm_exc_invalid_op+0x1b/0x20
[13519.468094]  ? drop_nlink+0x2c/0x40
[13519.468097]  simplefs_unlink+0x2e9/0x3b0 [simplefs]

```
the [inode_dec_link_count](https://elixir.bootlin.com/linux/v6.10.5/source/fs/inode.c#L330) has included drop_nlink and mark_inode_dirty