### PR TITLE
Fix user-space data write with incorrect offset

### DIFF
--- a/file.c
+++ b/file.c
@@ -413,8 +413,8 @@ static ssize_t simplefs_write(struct file *file,
         size_t bytes_to_write =
             min_t(size_t, len, SIMPLEFS_BLOCK_SIZE - pos % SIMPLEFS_BLOCK_SIZE);
 
-        if (copy_from_user(bh_data->b_data + pos % SIMPLEFS_BLOCK_SIZE, buf,
-                           bytes_to_write)) {
+        if (copy_from_user(bh_data->b_data + pos % SIMPLEFS_BLOCK_SIZE,
+                           buf + bytes_write, bytes_to_write)) {
             brelse(bh_data);
             bytes_write = -EFAULT;
             break;

--- a/script/test.sh
+++ b/script/test.sh
@@ -123,6 +123,18 @@ test_op 'dd if=/dev/zero of=file bs=1M count=12 status=none'
 filesize=$(sudo ls -lR  | grep -e "$F_MOD 2".*file | awk '{print $5}')
 test $filesize -le $MAXFILESIZE || echo "Failed, file size over the limit"
 
+# Write the file size larger than BLOCK_SIZE
+# test serial to write
+test_op 'printf \"%.0s123456789\" {1..1600} > file.txt'
+count=$(awk '{count += gsub(/123456789/, "")} END {print count}' "file.txt")
+echo "test $count"
+test "$count" -eq 1600 || echo "Failed, file size not matching"
+# test block to write
+test_op 'cat file.txt > checkfile.txt'
+count=$(awk '{count += gsub(/123456789/, "")} END {print count}' "checkfile.txt")
+echo "test $count"
+test "$count" -eq 1600 || echo "Failed, file size not matching"
+
 # test remove symbolic link
 test_op 'ln -s file symlink_fake'
 test_op 'rm -f symlink_fake'


### PR DESCRIPTION
	The simplefs_write will copy data from user space. If the
input length is larger than BLOCK_SIZE, the data will not be copied from user space buffer.

"dd" or "print" writes in batches, but "cat" writes the entire data at one.
So we add print and cat commands to test simplefs_write function.

close #66 

