### PR TITLE
Refine simplefs_sb_info to align with cacheline

### DIFF
--- a/simplefs.h
+++ b/simplefs.h
@@ -142,6 +142,8 @@ struct simplefs_sb_info {
     uint32_t nr_free_inodes; /* Number of free inodes */
     uint32_t nr_free_blocks; /* Number of free blocks */
 
+    unsigned long *ifree_bitmap; /* In-memory free inodes bitmap */
+    unsigned long *bfree_bitmap; /* In-memory free blocks bitmap */
 #ifdef __KERNEL__
     journal_t *journal;
     struct block_device *s_journal_bdev; /* v5.10+ external journal device */
@@ -150,10 +152,8 @@ struct simplefs_sb_info {
 #elif SIMPLEFS_AT_LEAST(6, 7, 0)
     struct bdev_handle
         *s_journal_bdev_handle; /* v6.7+ external journal device */
-#endif
-    unsigned long *ifree_bitmap; /* In-memory free inodes bitmap */
-    unsigned long *bfree_bitmap; /* In-memory free blocks bitmap */
-#endif
+#endif /* SIMPLEFS_AT_LEAST */
+#endif /* __KERNEL__ */
 };
 
 #endif /* SIMPLEFS_H */


### PR DESCRIPTION
The ifree_bitmap and ibfree_bitmap fields are frequently used together. To enhance performance, we reorganized the structure layout to align with 64-byte cache lines.

Using pahole to detect

```
struct simplefs_sb_info {
	uint32_t                   magic;                /*     0     4 */
	uint32_t                   nr_blocks;            /*     4     4 */
	uint32_t                   nr_inodes;            /*     8     4 */
	uint32_t                   nr_istore_blocks;     /*    12     4 */
	uint32_t                   nr_ifree_blocks;      /*    16     4 */
	uint32_t                   nr_bfree_blocks;      /*    20     4 */
	uint32_t                   nr_free_inodes;       /*    24     4 */
	uint32_t                   nr_free_blocks;       /*    28     4 */
	journal_t *                journal;              /*    32     8 */
	struct block_device *      s_journal_bdev;       /*    40     8 */
	struct file *              s_journal_bdev_file;  /*    48     8 */
	long unsigned int *        ifree_bitmap;         /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	long unsigned int *        bfree_bitmap;         /*    64     8 */

	/* size: 72, cachelines: 2, members: 13 */
	/* last cacheline: 8 bytes */
};
```
the ifree and bfree are in different cache line so I move it.
After modification

```
struct simplefs_sb_info {
	uint32_t                   magic;                /*     0     4 */
	uint32_t                   nr_blocks;            /*     4     4 */
	uint32_t                   nr_inodes;            /*     8     4 */
	uint32_t                   nr_istore_blocks;     /*    12     4 */
	uint32_t                   nr_ifree_blocks;      /*    16     4 */
	uint32_t                   nr_bfree_blocks;      /*    20     4 */
	uint32_t                   nr_free_inodes;       /*    24     4 */
	uint32_t                   nr_free_blocks;       /*    28     4 */
	long unsigned int *        ifree_bitmap;         /*    32     8 */
	long unsigned int *        bfree_bitmap;         /*    40     8 */
	journal_t *                journal;              /*    48     8 */
	struct block_device *      s_journal_bdev;       /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	struct file *              s_journal_bdev_file;  /*    64     8 */

	/* size: 72, cachelines: 2, members: 13 */
	/* last cacheline: 8 bytes */
};
```