### PR TITLE
Reclaim extent block when removing non-root dir

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -603,8 +603,6 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
     if (!bh)
         goto clean_inode;
     file_block = (struct simplefs_file_ei_block *) bh->b_data;
-    if (S_ISDIR(inode->i_mode))
-        goto scrub;
 
     for (ei = 0; ei < SIMPLEFS_MAX_EXTENTS; ei++) {
         char *block;
@@ -627,7 +625,6 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
         }
     }
 
-scrub:
     /* Scrub index block */
     memset(file_block, 0, SIMPLEFS_BLOCK_SIZE);
     mark_buffer_dirty(bh);

--- a/script/test_large_file.sh
+++ b/script/test_large_file.sh
@@ -1,0 +1,20 @@
+# file too large
+test_too_large_file() {
+    test_op 'dd if=/dev/zero of=file bs=1M count=12 status=none'
+    filesize=$(sudo ls -lR  | grep -e "$F_MOD 2".*file | awk '{print $5}')
+    test $filesize -le $MAXFILESIZE || echo "Failed, file size over the limit"
+}
+
+# Write the file size larger than BLOCK_SIZE
+# test serial to write
+test_file_size_larger_than_block_size() {
+    test_op 'yes 123456789 | head -n 1600 | tr -d "\n" > file.txt'
+    count=$(awk '{count += gsub(/123456789/, "")} END {print count}' "file.txt")
+    echo "test $count"
+    test "$count" -eq 1600 || echo "Failed, file size not matching"
+    # test block to write
+    test_op 'cat file.txt > checkfile.txt'
+    count=$(awk '{count += gsub(/123456789/, "")} END {print count}' "checkfile.txt")
+    echo "test $count"
+    test "$count" -eq 1600 || echo "Failed, file size not matching"
+}


### PR DESCRIPTION
When removing a directory, the extent block was not reclaimed properly.

This fix ensures that extent blocks for non-root directories are reclaimed during removal. The root directory is excluded from this process, as it serves as the mount point and cannot be removed.

The reclaim mechanism is designed to run when a directory is actually removed, not just when it becomes empty.

close #65