### PR TITLE
Use hash func to boost file creation and lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 obj-m += simplefs.o
-simplefs-objs := fs.o super.o inode.o file.o dir.o extent.o
+simplefs-objs := fs.o super.o inode.o file.o dir.o extent.o hash.o
 
 KDIR ?= /lib/modules/$(shell uname -r)/build
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ named `ei_block`. This field, `ei_block`, serves different purposes depending
 on the type of file:
   - For a directory, it contains the list of files within that directory.
     A directory can hold a maximum of 40,920 files, with filenames restricted
-    to a maximum of 255 characters to ensure they fit within a single block.
+    to a maximum of 254 characters to ensure they fit within a single block.
   ```
   inode
   +-----------------------+

--- a/dir.c
+++ b/dir.c
@@ -62,9 +62,10 @@ static int simplefs_iterate(struct file *dir, struct dir_context *ctx)
     for (; remained_nr_files && ei < SIMPLEFS_MAX_EXTENTS; ei++) {
         if (eblock->extents[ei].ee_start == 0)
             continue;
-
+        int ei_nr = eblock->extents[ei].nr_files;
         /* Iterate over blocks in one extent */
-        for (bi = 0; bi < eblock->extents[ei].ee_len && remained_nr_files;
+        for (bi = 0;
+             bi < eblock->extents[ei].ee_len && remained_nr_files && ei_nr;
              bi++) {
             bh2 = sb_bread(sb, eblock->extents[ei].ee_start + bi);
             if (!bh2) {
@@ -86,6 +87,7 @@ static int simplefs_iterate(struct file *dir, struct dir_context *ctx)
                         offset--;
                     } else {
                         remained_nr_files--;
+                        ei_nr--;
                         if (!dir_emit(ctx, dblock->files[fi].filename,
                                       SIMPLEFS_FILENAME_LEN,
                                       dblock->files[fi].inode, DT_UNKNOWN)) {

--- a/dir.c
+++ b/dir.c
@@ -81,7 +81,7 @@ static int simplefs_iterate(struct file *dir, struct dir_context *ctx)
                 continue;
             }
 
-            for (fi = 0; fi < SIMPLEFS_FILES_PER_BLOCK;) {
+            for (fi = 0; fi < SIMPLEFS_FILES_PER_BLOCK && dblock->nr_files;) {
                 if (dblock->files[fi].inode != 0) {
                     if (offset) {
                         offset--;

--- a/hash.c
+++ b/hash.c
@@ -1,0 +1,15 @@
+#include <linux/dcache.h>
+#include <linux/types.h>
+#include "simplefs.h"
+
+uint32_t simplefs_hash(struct dentry *dentry)
+{
+    const char *str = dentry->d_name.name;
+    uint64_t h = 0xcbf29ce484222325ULL;
+    while (*str) {
+        h ^= (unsigned char) (*str++);
+        h *= 0x100000001b3ULL;
+    }
+    /* Fold high 32 bits into low 32 bits to mix the full 64-bit result */
+    return (uint32_t) (h ^ (h >> 32));
+}

--- a/inode.c
+++ b/inode.c
@@ -11,6 +11,11 @@
 static const struct inode_operations simplefs_inode_ops;
 static const struct inode_operations symlink_inode_ops;
 
+#define CHECK_AND_SET_RING_INDEX(idx, len) \
+    do {                                   \
+        if (unlikely(idx >= len))          \
+            idx -= len;                    \
+    } while (0)
 /* Either return the inode that corresponds to a given inode number (ino), if
  * it is already in the cache, or create a new inode object if it is not in the
  * cache.
@@ -118,6 +123,76 @@ failed:
     return ERR_PTR(ret);
 }
 
+static int __file_lookup(struct inode *dir,
+                         struct dentry *dentry,
+                         int *ei,
+                         int *bi,
+                         int *fi)
+{
+    struct super_block *sb = dir->i_sb;
+    struct simplefs_inode_info *ci_dir = SIMPLEFS_INODE(dir);
+    struct buffer_head *bh = NULL, *bh2 = NULL;
+    struct simplefs_file_ei_block *eblock = NULL;
+    struct simplefs_dir_block *dblock = NULL;
+    struct simplefs_file *f = NULL;
+    int _ei, _bi, _fi, ret = -ENOENT;
+    int idx_ei, idx_bi;
+    uint32_t hash_code;
+
+    /* Read the directory block on disk */
+    bh = sb_bread(sb, ci_dir->ei_block);
+    if (!bh)
+        return -EIO;
+    eblock = (struct simplefs_file_ei_block *) bh->b_data;
+    hash_code = simplefs_hash(dentry) %
+                (SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_BLOCKS_PER_EXTENT);
+    _ei = hash_code / SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
+    _bi = hash_code % SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
+    int nr_ei_files = eblock->nr_files;
+    for (idx_ei = 0; nr_ei_files; _ei++, idx_ei++) {
+        CHECK_AND_SET_RING_INDEX(_ei, SIMPLEFS_MAX_EXTENTS);
+
+        if (!eblock->extents[_ei].ee_start)
+            continue;
+
+        nr_ei_files -= eblock->extents[_ei].nr_files;
+        /* Iterate blocks in extent */
+        int nr_bi_files = eblock->extents[_ei].nr_files;
+        for (idx_bi = 0; nr_bi_files; _bi++, idx_bi++) {
+            CHECK_AND_SET_RING_INDEX(_bi, eblock->extents[_ei].ee_len);
+
+            bh2 = sb_bread(sb, eblock->extents[_ei].ee_start + _bi);
+            if (!bh2) {
+                ret = -EIO;
+                goto file_search_end;
+            }
+
+            dblock = (struct simplefs_dir_block *) bh2->b_data;
+            /* Search file in ei_block */
+            nr_bi_files -= dblock->nr_files;
+            for (_fi = 0; _fi < SIMPLEFS_FILES_PER_BLOCK;) {
+                f = &dblock->files[_fi];
+                if (f->inode && !strncmp(f->filename, dentry->d_name.name,
+                                         SIMPLEFS_FILENAME_LEN - 1)) {
+                    *ei = _ei;
+                    *bi = _bi;
+                    *fi = _fi;
+
+                    brelse(bh);
+                    brelse(bh2);
+                    return 0;
+                }
+                _fi += dblock->files[_fi].nr_blk;
+            }
+            brelse(bh2);
+        }
+        _bi = 0;
+    }
+file_search_end:
+    brelse(bh);
+    return ret;
+}
+
 /* Search for a dentry in dir.
  * Fills dentry with NULL if not found in dir, or with the corresponding inode
  * if found.
@@ -134,18 +209,31 @@ static struct dentry *simplefs_lookup(struct inode *dir,
     struct buffer_head *bh = NULL, *bh2 = NULL;
     struct simplefs_file_ei_block *eblock = NULL;
     struct simplefs_dir_block *dblock = NULL;
-    struct simplefs_file *f = NULL;
-    int ei, bi, fi;
+    int ei, bi, fi, chk;
 
-    /* Check filename length */
-    if (dentry->d_name.len > SIMPLEFS_FILENAME_LEN)
+    /* Check filename length less than SIMPLEFS_FILENAME_LEN - 1, the last
+     * character is for null terminator */
+    if (dentry->d_name.len >= SIMPLEFS_FILENAME_LEN)
         return ERR_PTR(-ENAMETOOLONG);
 
     /* Read the directory block on disk */
+
+    chk = __file_lookup(dir, dentry, &ei, &bi, &fi);
+    if (chk == -ENOENT)
+        goto search_end; /* Not found, return NULL dentry */
+    if (chk < 0)
+        return ERR_PTR(chk); /* I/O error */
+
     bh = sb_bread(sb, ci_dir->ei_block);
     if (!bh)
         return ERR_PTR(-EIO);
+
     eblock = (struct simplefs_file_ei_block *) bh->b_data;
+    bh2 = sb_bread(sb, eblock->extents[ei].ee_start + bi);
+    if (!bh2) {
+        brelse(bh);
+        return ERR_PTR(-EIO);
+    }
 
     /* Search for the file in directory */
     for (ei = 0; ei < SIMPLEFS_MAX_EXTENTS; ei++) {
@@ -324,31 +412,30 @@ put_ino:
 }
 
 static uint32_t simplefs_get_available_ext_idx(
-    int *dir_nr_files,
-    struct simplefs_file_ei_block *eblock)
+    struct simplefs_file_ei_block *eblock,
+    uint32_t hash_code)
 {
-    int ei = 0;
+    int ei = 0, idx;
     uint32_t first_empty_blk = -1;
-    for (ei = 0; ei < SIMPLEFS_MAX_EXTENTS; ei++) {
-        if (eblock->extents[ei].ee_start &&
-            eblock->extents[ei].nr_files != SIMPLEFS_FILES_PER_EXT) {
+
+    ei = hash_code / SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
+
+    for (idx = 0; idx < SIMPLEFS_MAX_EXTENTS; ei++, idx++) {
+        CHECK_AND_SET_RING_INDEX(ei, SIMPLEFS_MAX_EXTENTS);
+
+        if (!eblock->extents[ei].ee_start) {
             first_empty_blk = ei;
             break;
-        } else if (!eblock->extents[ei].ee_start) {
-            if (first_empty_blk == -1)
-                first_empty_blk = ei;
-        } else {
-            *dir_nr_files -= eblock->extents[ei].nr_files;
-            if (first_empty_blk == -1 && !*dir_nr_files)
-                first_empty_blk = ei + 1;
-        }
-        if (!*dir_nr_files)
+        } else if (eblock->extents[ei].ee_start &&
+                   eblock->extents[ei].nr_files != SIMPLEFS_FILES_PER_EXT) {
+            first_empty_blk = ei;
             break;
+        }
     }
     return first_empty_blk;
 }
 
-static int simplefs_put_new_ext(struct super_block *sb,
+static int simplefs_get_new_ext(struct super_block *sb,
                                 uint32_t ei,
                                 struct simplefs_file_ei_block *eblock)
 {
@@ -361,9 +448,9 @@ static int simplefs_put_new_ext(struct super_block *sb,
 
     eblock->extents[ei].ee_start = bno;
     eblock->extents[ei].ee_len = SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
-    eblock->extents[ei].ee_block =
-        ei ? eblock->extents[ei - 1].ee_block + eblock->extents[ei - 1].ee_len
-           : 0;
+    /* ee_block is only used for file extent search, not for directory extents.
+     * Set to 0 as directory operations rely solely on ee_start and ee_len. */
+    eblock->extents[ei].ee_block = 0;
     eblock->extents[ei].nr_files = 0;
 
     /* clear the ext block*/
@@ -409,6 +496,39 @@ static void simplefs_set_file_into_dir(struct simplefs_dir_block *dblock,
     dblock->nr_files++;
 }
 
+static bool simplefs_try_remove_entry(struct simplefs_dir_block *dblock,
+                                      struct simplefs_file_ei_block *eblock,
+                                      int ei,
+                                      ino_t ino,
+                                      const char *name)
+{
+    int fi, i;
+    int blk_nr_files = dblock->nr_files;
+
+    for (fi = 0; blk_nr_files && fi < SIMPLEFS_FILES_PER_BLOCK;) {
+        if (dblock->files[fi].inode) {
+            if (dblock->files[fi].inode == ino &&
+                !strcmp(dblock->files[fi].filename, name)) {
+                dblock->files[fi].inode = 0;
+                /* Merge the empty data */
+                for (i = fi - 1; i >= 0; i--) {
+                    if (dblock->files[i].inode != 0 || i == 0) {
+                        dblock->files[i].nr_blk += dblock->files[fi].nr_blk;
+                        break;
+                    }
+                }
+                dblock->nr_files--;
+                eblock->extents[ei].nr_files--;
+                eblock->nr_files--;
+                return true;
+            }
+            blk_nr_files--;
+        }
+        fi += dblock->files[fi].nr_blk;
+    }
+    return false;
+}
+
 /* Create a file or directory in this way:
  *   - check filename length and if the parent directory is not full
  *   - create the new inode (allocate inode and blocks)
@@ -441,15 +561,17 @@ static int simplefs_create(struct inode *dir,
     struct simplefs_dir_block *dblock;
     char *fblock;
     struct buffer_head *bh, *bh2;
-    uint32_t dir_nr_files = 0, avail;
+    uint32_t avail;
 #if SIMPLEFS_AT_LEAST(6, 6, 0) && SIMPLEFS_LESS_EQUAL(6, 7, 0)
     struct timespec64 cur_time;
 #endif
     int ret = 0, alloc = false;
-    int bi = 0;
+    uint32_t hash_code;
+    int bi = 0, idx_bi;
 
-    /* Check filename length */
-    if (strlen(dentry->d_name.name) > SIMPLEFS_FILENAME_LEN)
+    /* Check filename length less than SIMPLEFS_FILENAME_LEN - 1, the last
+     * character is for null terminator */
+    if (strlen(dentry->d_name.name) >= SIMPLEFS_FILENAME_LEN)
         return -ENAMETOOLONG;
 
     /* Read parent directory index */
@@ -486,8 +608,9 @@ static int simplefs_create(struct inode *dir,
     mark_buffer_dirty(bh2);
     brelse(bh2);
 
-    dir_nr_files = eblock->nr_files;
-    avail = simplefs_get_available_ext_idx(&dir_nr_files, eblock);
+    hash_code = simplefs_hash(dentry) %
+                (SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_BLOCKS_PER_EXTENT);
+    avail = simplefs_get_available_ext_idx(eblock, hash_code);
 
     /* Validate avail index is within bounds */
     if (avail >= SIMPLEFS_MAX_EXTENTS) {
@@ -496,8 +619,8 @@ static int simplefs_create(struct inode *dir,
     }
 
     /* if there is not any empty space, alloc new one */
-    if (!dir_nr_files && !eblock->extents[avail].ee_start) {
-        ret = simplefs_put_new_ext(sb, avail, eblock);
+    if (!eblock->extents[avail].ee_start) {
+        ret = simplefs_get_new_ext(sb, avail, eblock);
         switch (ret) {
         case -ENOSPC:
             ret = -ENOSPC;
@@ -511,7 +634,10 @@ static int simplefs_create(struct inode *dir,
 
     /* TODO: fix from 8 to dynamic value */
     /* Find which simplefs_dir_block has free space */
-    for (bi = 0; bi < eblock->extents[avail].ee_len; bi++) {
+    bi = hash_code % eblock->extents[avail].ee_len;
+    for (idx_bi = 0; idx_bi < eblock->extents[avail].ee_len; bi++, idx_bi++) {
+        CHECK_AND_SET_RING_INDEX(bi, eblock->extents[avail].ee_len);
+
         bh2 = sb_bread(sb, eblock->extents[avail].ee_start + bi);
         if (!bh2) {
             ret = -EIO;
@@ -571,72 +697,66 @@ end:
     return ret;
 }
 
-static int simplefs_remove_from_dir(struct inode *dir, struct dentry *dentry)
+static int simplefs_remove_from_dir(struct inode *dir,
+                                    struct dentry *dentry,
+                                    int *ret_ei,
+                                    struct buffer_head **ret_ei_bh)
 {
     struct super_block *sb = dir->i_sb;
     struct inode *inode = d_inode(dentry);
-    struct buffer_head *bh = NULL, *bh2 = NULL;
+    struct buffer_head *bh2 = NULL;
     struct simplefs_file_ei_block *eblock = NULL;
     struct simplefs_dir_block *dirblk = NULL;
-    int ei = 0, bi = 0, fi = 0;
-    int ret = 0, found = false;
-
+    int ei = 0, bi = 0, idx_bi;
+    int ret = 0, found = false, dir_nr_files;
+    uint32_t hash_code;
     /* Read parent directory index */
-    bh = sb_bread(sb, SIMPLEFS_INODE(dir)->ei_block);
-    if (!bh)
+    *ret_ei_bh = sb_bread(sb, SIMPLEFS_INODE(dir)->ei_block);
+    if (!*ret_ei_bh)
         return -EIO;
 
-    eblock = (struct simplefs_file_ei_block *) bh->b_data;
+    eblock = (struct simplefs_file_ei_block *) (*ret_ei_bh)->b_data;
+    dir_nr_files = eblock->nr_files;
 
-    int dir_nr_files = eblock->nr_files;
-    for (ei = 0; dir_nr_files; ei++) {
+    hash_code = simplefs_hash(dentry) %
+                (SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_BLOCKS_PER_EXTENT);
+    ei = hash_code / SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
+    bi = hash_code % SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
+
+    for (; dir_nr_files; ei++) {
+        CHECK_AND_SET_RING_INDEX(ei, SIMPLEFS_MAX_EXTENTS);
+
         if (eblock->extents[ei].ee_start) {
             dir_nr_files -= eblock->extents[ei].nr_files;
-            for (bi = 0; bi < eblock->extents[ei].ee_len; bi++) {
+            /* simplefs_extent */
+            for (idx_bi = 0; idx_bi < eblock->extents[ei].ee_len;
+                 bi++, idx_bi++) {
+                CHECK_AND_SET_RING_INDEX(bi, eblock->extents[ei].ee_len);
                 bh2 = sb_bread(sb, eblock->extents[ei].ee_start + bi);
                 if (!bh2) {
                     ret = -EIO;
-                    goto release_bh;
+                    goto end_ret;
                 }
+                /* simplefs_dir_block */
                 dirblk = (struct simplefs_dir_block *) bh2->b_data;
-                int blk_nr_files = dirblk->nr_files;
-                for (fi = 0; blk_nr_files && fi < SIMPLEFS_FILES_PER_BLOCK;) {
-                    if (dirblk->files[fi].inode) {
-                        if (dirblk->files[fi].inode == inode->i_ino &&
-                            !strcmp(dirblk->files[fi].filename,
-                                    dentry->d_name.name)) {
-                            found = true;
-                            dirblk->files[fi].inode = 0;
-                            /* merge the empty data */
-                            for (int i = fi - 1; i >= 0; i--) {
-                                if (dirblk->files[i].inode != 0 || i == 0) {
-                                    dirblk->files[i].nr_blk +=
-                                        dirblk->files[fi].nr_blk;
-                                    break;
-                                }
-                            }
-                            dirblk->nr_files--;
-                            eblock->extents[ei].nr_files--;
-                            eblock->nr_files--;
-                            mark_buffer_dirty(bh2);
-                            brelse(bh2);
-                            found = true;
-                            goto found_data;
-                        }
-                        blk_nr_files--;
-                    }
-                    fi += dirblk->files[fi].nr_blk;
+                if (simplefs_try_remove_entry(dirblk, eblock, ei, inode->i_ino,
+                                              dentry->d_name.name)) {
+                    mark_buffer_dirty(bh2);
+                    brelse(bh2);
+                    found = true;
+                    *ret_ei = ei;
+                    goto found_data;
                 }
                 brelse(bh2);
             }
         }
+        bi = 0;
     }
 found_data:
     if (found) {
-        mark_buffer_dirty(bh);
+        mark_buffer_dirty(*ret_ei_bh);
     }
-release_bh:
-    brelse(bh);
+end_ret:
     return ret;
 }
 
@@ -653,7 +773,7 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
     struct simplefs_sb_info *sbi = SIMPLEFS_SB(sb);
     struct inode *inode = d_inode(dentry);
     struct buffer_head *bh = NULL, *bh2 = NULL;
-    struct simplefs_file_ei_block *file_block = NULL;
+    struct simplefs_file_ei_block *eblk = NULL;
     char *block;
 #if SIMPLEFS_AT_LEAST(6, 6, 0) && SIMPLEFS_LESS_EQUAL(6, 7, 0)
     struct timespec64 cur_time;
@@ -664,9 +784,20 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
     uint32_t ino = inode->i_ino;
     uint32_t bno = 0;
 
-    ret = simplefs_remove_from_dir(dir, dentry);
-    if (ret != 0)
+    ret = simplefs_remove_from_dir(dir, dentry, &ei, &bh);
+
+    if (ret != 0) {
+        brelse(bh);
         return ret;
+    }
+
+    eblk = (struct simplefs_file_ei_block *) bh->b_data;
+    if (!eblk->extents[ei].nr_files) {
+        put_blocks(sbi, eblk->extents[ei].ee_start, eblk->extents[ei].ee_len);
+        memset(&eblk->extents[ei], 0, sizeof(struct simplefs_extent));
+        mark_buffer_dirty(bh);
+    }
+    brelse(bh);
 
     if (S_ISLNK(inode->i_mode))
         goto clean_inode;
@@ -703,18 +834,16 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
     bh = sb_bread(sb, bno);
     if (!bh)
         goto clean_inode;
-    file_block = (struct simplefs_file_ei_block *) bh->b_data;
-
+    eblk = (struct simplefs_file_ei_block *) bh->b_data;
     for (ei = 0; ei < SIMPLEFS_MAX_EXTENTS; ei++) {
-        if (!file_block->extents[ei].ee_start)
+        if (!eblk->extents[ei].ee_start)
             break;
 
-        put_blocks(sbi, file_block->extents[ei].ee_start,
-                   file_block->extents[ei].ee_len);
+        put_blocks(sbi, eblk->extents[ei].ee_start, eblk->extents[ei].ee_len);
 
         /* Scrub the extent */
-        for (bi = 0; bi < file_block->extents[ei].ee_len; bi++) {
-            bh2 = sb_bread(sb, file_block->extents[ei].ee_start + bi);
+        for (bi = 0; bi < eblk->extents[ei].ee_len; bi++) {
+            bh2 = sb_bread(sb, eblk->extents[ei].ee_start + bi);
             if (!bh2)
                 continue;
             block = (char *) bh2->b_data;
@@ -725,7 +854,7 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
     }
 
     /* Scrub index block */
-    memset(file_block, 0, SIMPLEFS_BLOCK_SIZE);
+    memset(eblk, 0, SIMPLEFS_BLOCK_SIZE);
     mark_buffer_dirty(bh);
     brelse(bh);
 
@@ -782,118 +911,146 @@ static int simplefs_rename(struct inode *src_dir,
 #endif
 {
     struct super_block *sb = src_dir->i_sb;
+    struct simplefs_sb_info *sbi = SIMPLEFS_SB(sb);
     struct simplefs_inode_info *ci_dest = SIMPLEFS_INODE(dest_dir);
-    struct inode *src = d_inode(src_dentry);
-    struct buffer_head *bh_new = NULL, *bh2 = NULL;
-    struct simplefs_file_ei_block *eblk_dest = NULL;
+    struct inode *src_in = d_inode(src_dentry);
+    struct buffer_head *bh_fei_blk_src = NULL, *bh_fei_blk_dest = NULL,
+                       *bh_ext = NULL, *dest_bh_ext = NULL;
+    struct simplefs_file_ei_block *eblk_src = NULL, *eblk_dest = NULL;
     struct simplefs_dir_block *dblock = NULL;
 
 #if SIMPLEFS_AT_LEAST(6, 6, 0) && SIMPLEFS_LESS_EQUAL(6, 7, 0)
     struct timespec64 cur_time;
 #endif
 
-    int new_pos = -1, ret = 0;
-    int ei = 0, bi = 0, fi = 0, bno = 0;
+    int ret = 0, new_pos = 0, idx, chk;
+    int src_ei = 0, dest_ei = 0, bi = 0, fi = 0;
+    int dest_inserted = 0;
+    uint32_t hash_code;
 
     /* fail with these unsupported flags */
     if (flags & (RENAME_EXCHANGE | RENAME_WHITEOUT))
         return -EINVAL;
 
     /* Check if filename is not too long */
-    if (strlen(dest_dentry->d_name.name) > SIMPLEFS_FILENAME_LEN)
+    if (strlen(dest_dentry->d_name.name) >= SIMPLEFS_FILENAME_LEN)
         return -ENAMETOOLONG;
 
     /* Fail if dest_dentry exists or if dest_dir is full */
-    bh_new = sb_bread(sb, ci_dest->ei_block);
-    if (!bh_new)
+    bh_fei_blk_dest = sb_bread(sb, ci_dest->ei_block);
+    if (!bh_fei_blk_dest)
         return -EIO;
 
-    eblk_dest = (struct simplefs_file_ei_block *) bh_new->b_data;
-    for (ei = 0; new_pos < 0 && ei < SIMPLEFS_MAX_EXTENTS; ei++) {
-        if (!eblk_dest->extents[ei].ee_start)
-            break;
-
-        for (bi = 0; new_pos < 0 && bi < eblk_dest->extents[ei].ee_len; bi++) {
-            bh2 = sb_bread(sb, eblk_dest->extents[ei].ee_start + bi);
-            if (!bh2) {
-                ret = -EIO;
-                goto release_new;
-            }
-
-            dblock = (struct simplefs_dir_block *) bh2->b_data;
-            int blk_nr_files = dblock->nr_files;
-            for (fi = 0; blk_nr_files;) {
-                /* src and target are the same dir (inode is same) */
-                if (dest_dir == src_dir) {
-                    if (dblock->files[fi].inode &&
-                        !strncmp(dblock->files[fi].filename,
-                                 src_dentry->d_name.name,
-                                 SIMPLEFS_FILENAME_LEN)) {
-                        strncpy(dblock->files[fi].filename,
-                                dest_dentry->d_name.name, SIMPLEFS_FILENAME_LEN);
-                        mark_buffer_dirty(bh2);
-                        brelse(bh2);
-                        goto release_new;
-                    }
-                } else {
-                    /* src and target are different, then check if the
-                    same name in the target directory */
-                    if (dblock->files[fi].inode &&
-                        !strncmp(dblock->files[fi].filename,
-                                 dest_dentry->d_name.name,
-                                 SIMPLEFS_FILENAME_LEN)) {
-                        brelse(bh2);
-                        ret = -EEXIST;
-                        goto release_new;
-                    }
-                    /* find the empty index in target directory */
-                    if (new_pos < 0 && dblock->files[fi].nr_blk != 1) {
-                        new_pos = fi + 1;
-                        break;
-                    }
-                }
-                blk_nr_files--;
-                fi += dblock->files[fi].nr_blk;
-            }
-            brelse(bh2);
+    eblk_dest = (struct simplefs_file_ei_block *) bh_fei_blk_dest->b_data;
+    /* Search for the file in directory */
+    chk = __file_lookup(dest_dir, dest_dentry, &dest_ei, &bi, &fi);
+    if (chk != -ENOENT) {
+        if (chk == 0) { /* found, return exist */
+            ret = -EEXIST;
+        } else if (chk < 0) { /* I/O error */
+            ret = chk;
         }
+        goto release_new;
     }
 
-    /* If new directory is full, fail */
-    if (new_pos < 0 && eblk_dest->nr_files == SIMPLEFS_FILES_PER_EXT) {
+    if (dest_dir != src_dir && eblk_dest->nr_files == SIMPLEFS_MAX_SUBFILES) {
+        ret = -EMLINK;
+        goto release_new;
+    }
+    if (dest_dir == src_dir && eblk_dest->nr_files == SIMPLEFS_MAX_SUBFILES) {
+        chk = __file_lookup(src_dir, src_dentry, &src_ei, &bi, &fi);
+        if (chk != 0) {
+            ret = chk;
+            goto release_new;
+        }
+
+        bh_ext = sb_bread(sb, eblk_dest->extents[src_ei].ee_start + bi);
+        if (!bh_ext) {
+            ret = -EIO;
+            goto release_new;
+        }
+        dblock = (struct simplefs_dir_block *) bh_ext->b_data;
+
+        strncpy(dblock->files[fi].filename, dest_dentry->d_name.name,
+                SIMPLEFS_FILENAME_LEN - 1);
+        dblock->files[fi].filename[SIMPLEFS_FILENAME_LEN - 1] = '\0';
+        mark_buffer_dirty(bh_ext);
+
+        brelse(bh_ext);
+        bh_ext = NULL;
+        goto update_metadata;
+    }
+
+    hash_code = simplefs_hash(dest_dentry) %
+                (SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_BLOCKS_PER_EXTENT);
+    dest_ei = simplefs_get_available_ext_idx(eblk_dest, hash_code);
+    if (dest_ei >= SIMPLEFS_MAX_EXTENTS) {
         ret = -EMLINK;
         goto release_new;
     }
 
-    /* insert in new parent directory */
-    /* Get new freeblocks for extent if needed*/
-    if (new_pos < 0) {
-        bno = get_free_blocks(sb, SIMPLEFS_MAX_BLOCKS_PER_EXTENT);
-        if (!bno) {
+    if (!eblk_dest->extents[dest_ei].ee_start) {
+        ret = simplefs_get_new_ext(sb, dest_ei, eblk_dest);
+        switch (ret) {
+        case -ENOSPC:
             ret = -ENOSPC;
             goto release_new;
+        case -EIO:
+            ret = -EIO;
+            goto release_new;
         }
-        eblk_dest->extents[ei].ee_start = bno;
-        eblk_dest->extents[ei].ee_len = SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
-        eblk_dest->extents[ei].ee_block =
-            ei ? eblk_dest->extents[ei - 1].ee_block +
-                     eblk_dest->extents[ei - 1].ee_len
-               : 0;
-        bh2 = sb_bread(sb, eblk_dest->extents[ei].ee_start + 0);
-        if (!bh2) {
+        mark_buffer_dirty(bh_fei_blk_dest);
+        new_pos = 1;
+    }
+    /* copy src info into new directory */
+    bi = hash_code % eblk_dest->extents[dest_ei].ee_len;
+    for (idx = 0; idx < eblk_dest->extents[dest_ei].ee_len; bi++, idx++) {
+        CHECK_AND_SET_RING_INDEX(bi, eblk_dest->extents[dest_ei].ee_len);
+        dest_bh_ext = sb_bread(sb, eblk_dest->extents[dest_ei].ee_start + bi);
+        if (!dest_bh_ext) {
             ret = -EIO;
             goto put_block;
         }
-        dblock = (struct simplefs_dir_block *) bh2->b_data;
-        mark_buffer_dirty(bh_new);
-        new_pos = 0;
-    }
-    dblock->files[new_pos].inode = src->i_ino;
-    strncpy(dblock->files[new_pos].filename, dest_dentry->d_name.name,
-            SIMPLEFS_FILENAME_LEN);
-    mark_buffer_dirty(bh2);
-    brelse(bh2);
+        dblock = (struct simplefs_dir_block *) dest_bh_ext->b_data;
 
+        /* check if dir block is full*/
+        if (dblock->nr_files != SIMPLEFS_FILES_PER_BLOCK) {
+            simplefs_set_file_into_dir(dblock, src_in->i_ino,
+                                       dest_dentry->d_name.name);
+            eblk_dest->extents[dest_ei].nr_files++;
+            eblk_dest->nr_files++;
+            mark_buffer_dirty(dest_bh_ext);
+            mark_buffer_dirty(bh_fei_blk_dest);
+            /* Track that we inserted the file for cleanup on error */
+            dest_inserted = 1;
+            /* Hold dest_bh_ext until the source is removed successfully or
+             * the operation is rolled back.
+             */
+            break;
+        }
+        brelse(dest_bh_ext);
+    }
+
+    if (!dest_inserted) {
+        ret = -ENOSPC;
+        goto put_block;
+    }
+
+    /* remove target from old parent directory */
+    ret =
+        simplefs_remove_from_dir(src_dir, src_dentry, &src_ei, &bh_fei_blk_src);
+    if (ret != 0)
+        goto rm_new;
+
+    eblk_src = (struct simplefs_file_ei_block *) bh_fei_blk_src->b_data;
+    if (!eblk_src->extents[src_ei].nr_files) {
+        put_blocks(sbi, eblk_src->extents[src_ei].ee_start,
+                   eblk_src->extents[src_ei].ee_len);
+        memset(&eblk_src->extents[src_ei], 0, sizeof(struct simplefs_extent));
+        mark_buffer_dirty(bh_fei_blk_src);
+    }
+
+update_metadata:
     /* Update new parent inode metadata */
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
     simple_inode_init_ts(dest_dir);
@@ -906,16 +1063,10 @@ static int simplefs_rename(struct inode *src_dir,
         current_time(dest_dir);
 #endif
 
-    if (S_ISDIR(src->i_mode))
+    if (S_ISDIR(src_in->i_mode))
         inc_nlink(dest_dir);
     mark_inode_dirty(dest_dir);
 
-    /* remove target from old parent directory */
-    ret = simplefs_remove_from_dir(src_dir, src_dentry);
-    if (ret != 0)
-        goto release_new;
-
-        /* Update old parent inode metadata */
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
     simple_inode_init_ts(src_dir);
 #elif SIMPLEFS_AT_LEAST(6, 6, 0)
@@ -927,20 +1078,41 @@ static int simplefs_rename(struct inode *src_dir,
         current_time(src_dir);
 #endif
 
-    if (S_ISDIR(src->i_mode))
+    if (S_ISDIR(src_in->i_mode))
         drop_nlink(src_dir);
     mark_inode_dirty(src_dir);
 
-    return ret;
+    goto release_new;
+
+rm_new:
+    /* dest_dentry has no inode; undo insert without simplefs_remove_from_dir */
+    if (dest_inserted) {
+        /* Use the held directory block buffer to remove the inserted entry */
+        dblock = (struct simplefs_dir_block *) dest_bh_ext->b_data;
+        if (simplefs_try_remove_entry(dblock, eblk_dest, dest_ei, src_in->i_ino,
+                                      dest_dentry->d_name.name)) {
+            mark_buffer_dirty(dest_bh_ext);
+            mark_buffer_dirty(bh_fei_blk_dest);
+        } else { /* this should never happen */
+            pr_warn(
+                "simplefs: failed to remove inserted entry on rename rollback "
+                "(leak)\n");
+        }
+        brelse(dest_bh_ext);
+        dest_bh_ext = NULL;
+    }
 
 put_block:
-    if (eblk_dest->extents[ei].ee_start) {
-        put_blocks(SIMPLEFS_SB(sb), eblk_dest->extents[ei].ee_start,
-                   eblk_dest->extents[ei].ee_len);
-        memset(&eblk_dest->extents[ei], 0, sizeof(struct simplefs_extent));
+    if (eblk_dest->extents[dest_ei].ee_start && new_pos) {
+        put_blocks(SIMPLEFS_SB(sb), eblk_dest->extents[dest_ei].ee_start,
+                   eblk_dest->extents[dest_ei].ee_len);
+        memset(&eblk_dest->extents[dest_ei], 0, sizeof(struct simplefs_extent));
     }
+
 release_new:
-    brelse(bh_new);
+    brelse(bh_fei_blk_dest);
+    brelse(bh_fei_blk_src);
+    brelse(dest_bh_ext);
     return ret;
 }
 
@@ -1015,8 +1187,8 @@ static int simplefs_link(struct dentry *src_dentry,
     struct simplefs_dir_block *dblock;
     struct buffer_head *bh = NULL, *bh2 = NULL;
     int ret = 0, alloc = false;
-    int ei = 0, bi = 0;
-    uint32_t avail;
+    int bi = 0, idx_bi;
+    uint32_t avail, hash_code;
 
     bh = sb_bread(sb, ci_dir->ei_block);
     if (!bh)
@@ -1029,8 +1201,10 @@ static int simplefs_link(struct dentry *src_dentry,
         goto end;
     }
 
-    int dir_nr_files = eblock->nr_files;
-    avail = simplefs_get_available_ext_idx(&dir_nr_files, eblock);
+
+    hash_code = simplefs_hash(dentry) %
+                (SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_BLOCKS_PER_EXTENT);
+    avail = simplefs_get_available_ext_idx(eblock, hash_code);
 
     /* Validate avail index is within bounds */
     if (avail >= SIMPLEFS_MAX_EXTENTS) {
@@ -1039,8 +1213,8 @@ static int simplefs_link(struct dentry *src_dentry,
     }
 
     /* if there is not any empty space, alloc new one */
-    if (!dir_nr_files && !eblock->extents[avail].ee_start) {
-        ret = simplefs_put_new_ext(sb, avail, eblock);
+    if (!eblock->extents[avail].ee_start) {
+        ret = simplefs_get_new_ext(sb, avail, eblock);
         switch (ret) {
         case -ENOSPC:
             ret = -ENOSPC;
@@ -1054,12 +1228,16 @@ static int simplefs_link(struct dentry *src_dentry,
 
     /* TODO: fix from 8 to dynamic value */
     /* Find which simplefs_dir_block has free space */
-    for (bi = 0; bi < eblock->extents[avail].ee_len; bi++) {
+    bi = hash_code % eblock->extents[avail].ee_len;
+    for (idx_bi = 0; idx_bi < eblock->extents[avail].ee_len; bi++, idx_bi++) {
+        CHECK_AND_SET_RING_INDEX(bi, eblock->extents[avail].ee_len);
+
         bh2 = sb_bread(sb, eblock->extents[avail].ee_start + bi);
         if (!bh2) {
             ret = -EIO;
             goto put_block;
         }
+
         dblock = (struct simplefs_dir_block *) bh2->b_data;
         if (dblock->nr_files != SIMPLEFS_FILES_PER_BLOCK)
             break;
@@ -1069,7 +1247,6 @@ static int simplefs_link(struct dentry *src_dentry,
 
     /* write the file info into simplefs_dir_block */
     simplefs_set_file_into_dir(dblock, old_inode->i_ino, dentry->d_name.name);
-
     eblock->extents[avail].nr_files++;
     eblock->nr_files++;
     mark_buffer_dirty(bh2);
@@ -1083,10 +1260,10 @@ static int simplefs_link(struct dentry *src_dentry,
     return ret;
 
 put_block:
-    if (alloc && eblock->extents[ei].ee_start) {
-        put_blocks(SIMPLEFS_SB(sb), eblock->extents[ei].ee_start,
-                   eblock->extents[ei].ee_len);
-        memset(&eblock->extents[ei], 0, sizeof(struct simplefs_extent));
+    if (alloc && eblock->extents[avail].ee_start) {
+        put_blocks(SIMPLEFS_SB(sb), eblock->extents[avail].ee_start,
+                   eblock->extents[avail].ee_len);
+        memset(&eblock->extents[avail], 0, sizeof(struct simplefs_extent));
     }
 end:
     brelse(bh);
@@ -1118,8 +1295,8 @@ static int simplefs_symlink(struct inode *dir,
     struct simplefs_dir_block *dblock = NULL;
     struct buffer_head *bh = NULL, *bh2 = NULL;
     int ret = 0, alloc = false;
-    int ei = 0, bi = 0;
-    uint32_t avail;
+    int bi = 0, idx_bi;
+    uint32_t avail, hash_code;
 
     /* Check if symlink content is not too long */
     if (l > sizeof(ci->i_data)) {
@@ -1141,8 +1318,10 @@ static int simplefs_symlink(struct inode *dir,
         goto iput;
     }
 
-    int dir_nr_files = eblock->nr_files;
-    avail = simplefs_get_available_ext_idx(&dir_nr_files, eblock);
+
+    hash_code = simplefs_hash(dentry) %
+                (SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_BLOCKS_PER_EXTENT);
+    avail = simplefs_get_available_ext_idx(eblock, hash_code);
 
     /* Validate avail index is within bounds */
     if (avail >= SIMPLEFS_MAX_EXTENTS) {
@@ -1151,8 +1330,8 @@ static int simplefs_symlink(struct inode *dir,
     }
 
     /* if there is not any empty space, alloc new one */
-    if (!dir_nr_files && !eblock->extents[avail].ee_start) {
-        ret = simplefs_put_new_ext(sb, avail, eblock);
+    if (!eblock->extents[avail].ee_start) {
+        ret = simplefs_get_new_ext(sb, avail, eblock);
         switch (ret) {
         case -ENOSPC:
             ret = -ENOSPC;
@@ -1166,12 +1345,16 @@ static int simplefs_symlink(struct inode *dir,
 
     /* TODO: fix from 8 to dynamic value */
     /* Find which simplefs_dir_block has free space */
-    for (bi = 0; bi < eblock->extents[avail].ee_len; bi++) {
+    bi = hash_code % eblock->extents[avail].ee_len;
+    for (idx_bi = 0; idx_bi < eblock->extents[avail].ee_len; bi++, idx_bi++) {
+        CHECK_AND_SET_RING_INDEX(bi, eblock->extents[avail].ee_len);
+
         bh2 = sb_bread(sb, eblock->extents[avail].ee_start + bi);
         if (!bh2) {
             ret = -EIO;
             goto put_block;
         }
+
         dblock = (struct simplefs_dir_block *) bh2->b_data;
         if (dblock->nr_files != SIMPLEFS_FILES_PER_BLOCK)
             break;
@@ -1197,10 +1380,10 @@ static int simplefs_symlink(struct inode *dir,
     return 0;
 
 put_block:
-    if (alloc && eblock->extents[ei].ee_start) {
-        put_blocks(SIMPLEFS_SB(sb), eblock->extents[ei].ee_start,
-                   eblock->extents[ei].ee_len);
-        memset(&eblock->extents[ei], 0, sizeof(struct simplefs_extent));
+    if (alloc && eblock->extents[avail].ee_start) {
+        put_blocks(SIMPLEFS_SB(sb), eblock->extents[avail].ee_start,
+                   eblock->extents[avail].ee_len);
+        memset(&eblock->extents[avail], 0, sizeof(struct simplefs_extent));
     }
 iput:
     put_blocks(SIMPLEFS_SB(sb), ci->ei_block, 1);

--- a/inode.c
+++ b/inode.c
@@ -761,31 +761,31 @@ clean_inode:
 
 #if SIMPLEFS_AT_LEAST(6, 3, 0)
 static int simplefs_rename(struct mnt_idmap *id,
-                           struct inode *old_dir,
-                           struct dentry *old_dentry,
-                           struct inode *new_dir,
-                           struct dentry *new_dentry,
+                           struct inode *src_dir,
+                           struct dentry *src_dentry,
+                           struct inode *dest_dir,
+                           struct dentry *dest_dentry,
                            unsigned int flags)
 #elif SIMPLEFS_AT_LEAST(5, 12, 0)
 static int simplefs_rename(struct user_namespace *ns,
-                           struct inode *old_dir,
-                           struct dentry *old_dentry,
-                           struct inode *new_dir,
-                           struct dentry *new_dentry,
+                           struct inode *src_dir,
+                           struct dentry *src_dentry,
+                           struct inode *dest_dir,
+                           struct dentry *dest_dentry,
                            unsigned int flags)
 #else
-static int simplefs_rename(struct inode *old_dir,
-                           struct dentry *old_dentry,
-                           struct inode *new_dir,
-                           struct dentry *new_dentry,
+static int simplefs_rename(struct inode *src_dir,
+                           struct dentry *src_dentry,
+                           struct inode *dest_dir,
+                           struct dentry *dest_dentry,
                            unsigned int flags)
 #endif
 {
-    struct super_block *sb = old_dir->i_sb;
-    struct simplefs_inode_info *ci_new = SIMPLEFS_INODE(new_dir);
-    struct inode *src = d_inode(old_dentry);
+    struct super_block *sb = src_dir->i_sb;
+    struct simplefs_inode_info *ci_dest = SIMPLEFS_INODE(dest_dir);
+    struct inode *src = d_inode(src_dentry);
     struct buffer_head *bh_new = NULL, *bh2 = NULL;
-    struct simplefs_file_ei_block *eblock_new = NULL;
+    struct simplefs_file_ei_block *eblk_dest = NULL;
     struct simplefs_dir_block *dblock = NULL;
 
 #if SIMPLEFS_AT_LEAST(6, 6, 0) && SIMPLEFS_LESS_EQUAL(6, 7, 0)
@@ -800,21 +800,21 @@ static int simplefs_rename(struct inode *old_dir,
         return -EINVAL;
 
     /* Check if filename is not too long */
-    if (strlen(new_dentry->d_name.name) > SIMPLEFS_FILENAME_LEN)
+    if (strlen(dest_dentry->d_name.name) > SIMPLEFS_FILENAME_LEN)
         return -ENAMETOOLONG;
 
-    /* Fail if new_dentry exists or if new_dir is full */
-    bh_new = sb_bread(sb, ci_new->ei_block);
+    /* Fail if dest_dentry exists or if dest_dir is full */
+    bh_new = sb_bread(sb, ci_dest->ei_block);
     if (!bh_new)
         return -EIO;
 
-    eblock_new = (struct simplefs_file_ei_block *) bh_new->b_data;
+    eblk_dest = (struct simplefs_file_ei_block *) bh_new->b_data;
     for (ei = 0; new_pos < 0 && ei < SIMPLEFS_MAX_EXTENTS; ei++) {
-        if (!eblock_new->extents[ei].ee_start)
+        if (!eblk_dest->extents[ei].ee_start)
             break;
 
-        for (bi = 0; new_pos < 0 && bi < eblock_new->extents[ei].ee_len; bi++) {
-            bh2 = sb_bread(sb, eblock_new->extents[ei].ee_start + bi);
+        for (bi = 0; new_pos < 0 && bi < eblk_dest->extents[ei].ee_len; bi++) {
+            bh2 = sb_bread(sb, eblk_dest->extents[ei].ee_start + bi);
             if (!bh2) {
                 ret = -EIO;
                 goto release_new;
@@ -824,13 +824,13 @@ static int simplefs_rename(struct inode *old_dir,
             int blk_nr_files = dblock->nr_files;
             for (fi = 0; blk_nr_files;) {
                 /* src and target are the same dir (inode is same) */
-                if (new_dir == old_dir) {
+                if (dest_dir == src_dir) {
                     if (dblock->files[fi].inode &&
                         !strncmp(dblock->files[fi].filename,
-                                 old_dentry->d_name.name,
+                                 src_dentry->d_name.name,
                                  SIMPLEFS_FILENAME_LEN)) {
                         strncpy(dblock->files[fi].filename,
-                                new_dentry->d_name.name, SIMPLEFS_FILENAME_LEN);
+                                dest_dentry->d_name.name, SIMPLEFS_FILENAME_LEN);
                         mark_buffer_dirty(bh2);
                         brelse(bh2);
                         goto release_new;
@@ -840,7 +840,7 @@ static int simplefs_rename(struct inode *old_dir,
                     same name in the target directory */
                     if (dblock->files[fi].inode &&
                         !strncmp(dblock->files[fi].filename,
-                                 new_dentry->d_name.name,
+                                 dest_dentry->d_name.name,
                                  SIMPLEFS_FILENAME_LEN)) {
                         brelse(bh2);
                         ret = -EEXIST;
@@ -860,7 +860,7 @@ static int simplefs_rename(struct inode *old_dir,
     }
 
     /* If new directory is full, fail */
-    if (new_pos < 0 && eblock_new->nr_files == SIMPLEFS_FILES_PER_EXT) {
+    if (new_pos < 0 && eblk_dest->nr_files == SIMPLEFS_FILES_PER_EXT) {
         ret = -EMLINK;
         goto release_new;
     }
@@ -873,13 +873,13 @@ static int simplefs_rename(struct inode *old_dir,
             ret = -ENOSPC;
             goto release_new;
         }
-        eblock_new->extents[ei].ee_start = bno;
-        eblock_new->extents[ei].ee_len = SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
-        eblock_new->extents[ei].ee_block =
-            ei ? eblock_new->extents[ei - 1].ee_block +
-                     eblock_new->extents[ei - 1].ee_len
+        eblk_dest->extents[ei].ee_start = bno;
+        eblk_dest->extents[ei].ee_len = SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
+        eblk_dest->extents[ei].ee_block =
+            ei ? eblk_dest->extents[ei - 1].ee_block +
+                     eblk_dest->extents[ei - 1].ee_len
                : 0;
-        bh2 = sb_bread(sb, eblock_new->extents[ei].ee_start + 0);
+        bh2 = sb_bread(sb, eblk_dest->extents[ei].ee_start + 0);
         if (!bh2) {
             ret = -EIO;
             goto put_block;
@@ -889,55 +889,55 @@ static int simplefs_rename(struct inode *old_dir,
         new_pos = 0;
     }
     dblock->files[new_pos].inode = src->i_ino;
-    strncpy(dblock->files[new_pos].filename, new_dentry->d_name.name,
+    strncpy(dblock->files[new_pos].filename, dest_dentry->d_name.name,
             SIMPLEFS_FILENAME_LEN);
     mark_buffer_dirty(bh2);
     brelse(bh2);
 
     /* Update new parent inode metadata */
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
-    simple_inode_init_ts(new_dir);
+    simple_inode_init_ts(dest_dir);
 #elif SIMPLEFS_AT_LEAST(6, 6, 0)
-    cur_time = current_time(new_dir);
-    new_dir->i_atime = new_dir->i_mtime = cur_time;
-    inode_set_ctime_to_ts(new_dir, cur_time);
+    cur_time = current_time(dest_dir);
+    dest_dir->i_atime = dest_dir->i_mtime = cur_time;
+    inode_set_ctime_to_ts(dest_dir, cur_time);
 #else
-    new_dir->i_atime = new_dir->i_ctime = new_dir->i_mtime =
-        current_time(new_dir);
+    dest_dir->i_atime = dest_dir->i_ctime = dest_dir->i_mtime =
+        current_time(dest_dir);
 #endif
 
     if (S_ISDIR(src->i_mode))
-        inc_nlink(new_dir);
-    mark_inode_dirty(new_dir);
+        inc_nlink(dest_dir);
+    mark_inode_dirty(dest_dir);
 
     /* remove target from old parent directory */
-    ret = simplefs_remove_from_dir(old_dir, old_dentry);
+    ret = simplefs_remove_from_dir(src_dir, src_dentry);
     if (ret != 0)
         goto release_new;
 
         /* Update old parent inode metadata */
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
-    simple_inode_init_ts(old_dir);
+    simple_inode_init_ts(src_dir);
 #elif SIMPLEFS_AT_LEAST(6, 6, 0)
-    cur_time = current_time(old_dir);
-    old_dir->i_atime = old_dir->i_mtime = cur_time;
-    inode_set_ctime_to_ts(old_dir, cur_time);
+    cur_time = current_time(src_dir);
+    src_dir->i_atime = src_dir->i_mtime = cur_time;
+    inode_set_ctime_to_ts(src_dir, cur_time);
 #else
-    old_dir->i_atime = old_dir->i_ctime = old_dir->i_mtime =
-        current_time(old_dir);
+    src_dir->i_atime = src_dir->i_ctime = src_dir->i_mtime =
+        current_time(src_dir);
 #endif
 
     if (S_ISDIR(src->i_mode))
-        drop_nlink(old_dir);
-    mark_inode_dirty(old_dir);
+        drop_nlink(src_dir);
+    mark_inode_dirty(src_dir);
 
     return ret;
 
 put_block:
-    if (eblock_new->extents[ei].ee_start) {
-        put_blocks(SIMPLEFS_SB(sb), eblock_new->extents[ei].ee_start,
-                   eblock_new->extents[ei].ee_len);
-        memset(&eblock_new->extents[ei], 0, sizeof(struct simplefs_extent));
+    if (eblk_dest->extents[ei].ee_start) {
+        put_blocks(SIMPLEFS_SB(sb), eblk_dest->extents[ei].ee_start,
+                   eblk_dest->extents[ei].ee_len);
+        memset(&eblk_dest->extents[ei], 0, sizeof(struct simplefs_extent));
     }
 release_new:
     brelse(bh_new);
@@ -1004,11 +1004,11 @@ static int simplefs_rmdir(struct inode *dir, struct dentry *dentry)
     return simplefs_unlink(dir, dentry);
 }
 
-static int simplefs_link(struct dentry *old_dentry,
+static int simplefs_link(struct dentry *src_dentry,
                          struct inode *dir,
                          struct dentry *dentry)
 {
-    struct inode *old_inode = d_inode(old_dentry);
+    struct inode *old_inode = d_inode(src_dentry);
     struct super_block *sb = old_inode->i_sb;
     struct simplefs_inode_info *ci_dir = SIMPLEFS_INODE(dir);
     struct simplefs_file_ei_block *eblock = NULL;

--- a/inode.c
+++ b/inode.c
@@ -16,6 +16,12 @@ static const struct inode_operations symlink_inode_ops;
         if (unlikely(idx >= len))          \
             idx -= len;                    \
     } while (0)
+
+#define RELEASE_BUFFER_HEAD(bh) \
+    do {                        \
+        brelse(bh);             \
+        bh = NULL;              \
+    } while (0)
 /* Either return the inode that corresponds to a given inode number (ino), if
  * it is already in the cache, or create a new inode object if it is not in the
  * cache.
@@ -110,7 +116,7 @@ struct inode *simplefs_iget(struct super_block *sb, unsigned long ino)
         inode->i_op = &symlink_inode_ops;
     }
 
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh);
 
     /* Unlock the inode to make it usable */
     unlock_new_inode(inode);
@@ -118,7 +124,7 @@ struct inode *simplefs_iget(struct super_block *sb, unsigned long ino)
     return inode;
 
 failed:
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh);
     iget_failed(inode);
     return ERR_PTR(ret);
 }
@@ -127,11 +133,12 @@ static int __file_lookup(struct inode *dir,
                          struct dentry *dentry,
                          int *ei,
                          int *bi,
-                         int *fi)
+                         int *fi,
+                         struct buffer_head **ret_ei_bh,
+                         struct buffer_head **ret_bi_bh)
 {
     struct super_block *sb = dir->i_sb;
     struct simplefs_inode_info *ci_dir = SIMPLEFS_INODE(dir);
-    struct buffer_head *bh = NULL, *bh2 = NULL;
     struct simplefs_file_ei_block *eblock = NULL;
     struct simplefs_dir_block *dblock = NULL;
     struct simplefs_file *f = NULL;
@@ -140,10 +147,10 @@ static int __file_lookup(struct inode *dir,
     uint32_t hash_code;
 
     /* Read the directory block on disk */
-    bh = sb_bread(sb, ci_dir->ei_block);
-    if (!bh)
+    *ret_ei_bh = sb_bread(sb, ci_dir->ei_block);
+    if (!*ret_ei_bh)
         return -EIO;
-    eblock = (struct simplefs_file_ei_block *) bh->b_data;
+    eblock = (struct simplefs_file_ei_block *) (*ret_ei_bh)->b_data;
     hash_code = simplefs_hash(dentry) %
                 (SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_BLOCKS_PER_EXTENT);
     _ei = hash_code / SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
@@ -161,13 +168,13 @@ static int __file_lookup(struct inode *dir,
         for (idx_bi = 0; nr_bi_files; _bi++, idx_bi++) {
             CHECK_AND_SET_RING_INDEX(_bi, eblock->extents[_ei].ee_len);
 
-            bh2 = sb_bread(sb, eblock->extents[_ei].ee_start + _bi);
-            if (!bh2) {
+            *ret_bi_bh = sb_bread(sb, eblock->extents[_ei].ee_start + _bi);
+            if (!*ret_bi_bh) {
                 ret = -EIO;
                 goto file_search_end;
             }
 
-            dblock = (struct simplefs_dir_block *) bh2->b_data;
+            dblock = (struct simplefs_dir_block *) (*ret_bi_bh)->b_data;
             /* Search file in ei_block */
             nr_bi_files -= dblock->nr_files;
             for (_fi = 0; _fi < SIMPLEFS_FILES_PER_BLOCK;) {
@@ -177,19 +184,15 @@ static int __file_lookup(struct inode *dir,
                     *ei = _ei;
                     *bi = _bi;
                     *fi = _fi;
-
-                    brelse(bh);
-                    brelse(bh2);
                     return 0;
                 }
                 _fi += dblock->files[_fi].nr_blk;
             }
-            brelse(bh2);
+            RELEASE_BUFFER_HEAD(*ret_bi_bh);
         }
         _bi = 0;
     }
 file_search_end:
-    brelse(bh);
     return ret;
 }
 
@@ -204,10 +207,8 @@ static struct dentry *simplefs_lookup(struct inode *dir,
                                       unsigned int flags)
 {
     struct super_block *sb = dir->i_sb;
-    struct simplefs_inode_info *ci_dir = SIMPLEFS_INODE(dir);
     struct inode *inode = NULL;
-    struct buffer_head *bh = NULL, *bh2 = NULL;
-    struct simplefs_file_ei_block *eblock = NULL;
+    struct buffer_head *ei_bh = NULL, *bi_bh = NULL;
     struct simplefs_dir_block *dblock = NULL;
     int ei, bi, fi, chk;
 
@@ -218,61 +219,27 @@ static struct dentry *simplefs_lookup(struct inode *dir,
 
     /* Read the directory block on disk */
 
-    chk = __file_lookup(dir, dentry, &ei, &bi, &fi);
+    chk = __file_lookup(dir, dentry, &ei, &bi, &fi, &ei_bh, &bi_bh);
     if (chk == -ENOENT)
         goto search_end; /* Not found, return NULL dentry */
-    if (chk < 0)
+    if (chk < 0) {
+        RELEASE_BUFFER_HEAD(ei_bh);
+        RELEASE_BUFFER_HEAD(bi_bh);
         return ERR_PTR(chk); /* I/O error */
-
-    bh = sb_bread(sb, ci_dir->ei_block);
-    if (!bh)
-        return ERR_PTR(-EIO);
-
-    eblock = (struct simplefs_file_ei_block *) bh->b_data;
-    bh2 = sb_bread(sb, eblock->extents[ei].ee_start + bi);
-    if (!bh2) {
-        brelse(bh);
-        return ERR_PTR(-EIO);
     }
 
-    /* Search for the file in directory */
-    for (ei = 0; ei < SIMPLEFS_MAX_EXTENTS; ei++) {
-        if (!eblock->extents[ei].ee_start)
-            break;
+    dblock = (struct simplefs_dir_block *) bi_bh->b_data;
+    inode = simplefs_iget(sb, (&dblock->files[fi])->inode);
 
-        /* Iterate blocks in extent */
-        for (bi = 0; bi < eblock->extents[ei].ee_len; bi++) {
-            bh2 = sb_bread(sb, eblock->extents[ei].ee_start + bi);
-            if (!bh2) {
-                brelse(bh);
-                return ERR_PTR(-EIO);
-            }
-
-            dblock = (struct simplefs_dir_block *) bh2->b_data;
-            int nr_files = dblock->nr_files;
-            /* Search file in ei_block */
-            for (fi = 0; nr_files && fi < SIMPLEFS_FILES_PER_BLOCK;) {
-                f = &dblock->files[fi];
-
-                if (f->inode) {
-                    nr_files--;
-                    if (!strncmp(f->filename, dentry->d_name.name,
-                                 SIMPLEFS_FILENAME_LEN)) {
-                        inode = simplefs_iget(sb, f->inode);
-                        brelse(bh2);
-                        goto search_end;
-                    }
-                }
-                fi += f->nr_blk;
-            }
-            brelse(bh2);
-            bh2 = NULL;
-        }
+    if (IS_ERR(inode)) {
+        RELEASE_BUFFER_HEAD(ei_bh);
+        RELEASE_BUFFER_HEAD(bi_bh);
+        return ERR_PTR(PTR_ERR(inode));
     }
 
 search_end:
-    brelse(bh);
-    bh = NULL;
+    RELEASE_BUFFER_HEAD(ei_bh);
+    RELEASE_BUFFER_HEAD(bi_bh);
     /* Update directory access time */
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
     inode_set_atime_to_ts(dir, current_time(dir));
@@ -463,7 +430,7 @@ static int simplefs_get_new_ext(struct super_block *sb,
         dblock = (struct simplefs_dir_block *) bh->b_data;
         memset(dblock, 0, sizeof(struct simplefs_dir_block));
         dblock->files[0].nr_blk = SIMPLEFS_FILES_PER_BLOCK;
-        brelse(bh);
+        RELEASE_BUFFER_HEAD(bh);
     }
     return 0;
 }
@@ -606,7 +573,7 @@ static int simplefs_create(struct inode *dir,
     fblock = (char *) bh2->b_data;
     memset(fblock, 0, SIMPLEFS_BLOCK_SIZE);
     mark_buffer_dirty(bh2);
-    brelse(bh2);
+    RELEASE_BUFFER_HEAD(bh2);
 
     hash_code = simplefs_hash(dentry) %
                 (SIMPLEFS_MAX_EXTENTS * SIMPLEFS_MAX_BLOCKS_PER_EXTENT);
@@ -647,7 +614,7 @@ static int simplefs_create(struct inode *dir,
         if (dblock->nr_files != SIMPLEFS_FILES_PER_BLOCK)
             break;
         else
-            brelse(bh2);
+            RELEASE_BUFFER_HEAD(bh2);
     }
 
     /* write the file info into simplefs_dir_block */
@@ -657,8 +624,8 @@ static int simplefs_create(struct inode *dir,
     eblock->nr_files++;
     mark_buffer_dirty(bh2);
     mark_buffer_dirty(bh);
-    brelse(bh2);
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh2);
+    RELEASE_BUFFER_HEAD(bh);
 
     /* Update stats and mark dir and new inode dirty */
     mark_inode_dirty(inode);
@@ -693,7 +660,7 @@ iput:
     put_inode(SIMPLEFS_SB(sb), inode->i_ino);
     iput(inode);
 end:
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh);
     return ret;
 }
 
@@ -742,12 +709,12 @@ static int simplefs_remove_from_dir(struct inode *dir,
                 if (simplefs_try_remove_entry(dirblk, eblock, ei, inode->i_ino,
                                               dentry->d_name.name)) {
                     mark_buffer_dirty(bh2);
-                    brelse(bh2);
+                    RELEASE_BUFFER_HEAD(bh2);
                     found = true;
                     *ret_ei = ei;
                     goto found_data;
                 }
-                brelse(bh2);
+                RELEASE_BUFFER_HEAD(bh2);
             }
         }
         bi = 0;
@@ -787,7 +754,7 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
     ret = simplefs_remove_from_dir(dir, dentry, &ei, &bh);
 
     if (ret != 0) {
-        brelse(bh);
+        RELEASE_BUFFER_HEAD(bh);
         return ret;
     }
 
@@ -797,7 +764,7 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
         memset(&eblk->extents[ei], 0, sizeof(struct simplefs_extent));
         mark_buffer_dirty(bh);
     }
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh);
 
     if (S_ISLNK(inode->i_mode))
         goto clean_inode;
@@ -849,14 +816,14 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
             block = (char *) bh2->b_data;
             memset(block, 0, SIMPLEFS_BLOCK_SIZE);
             mark_buffer_dirty(bh2);
-            brelse(bh2);
+            RELEASE_BUFFER_HEAD(bh2);
         }
     }
 
     /* Scrub index block */
     memset(eblk, 0, SIMPLEFS_BLOCK_SIZE);
     mark_buffer_dirty(bh);
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh);
 
 clean_inode:
     /* Cleanup inode and mark dirty */
@@ -912,10 +879,9 @@ static int simplefs_rename(struct inode *src_dir,
 {
     struct super_block *sb = src_dir->i_sb;
     struct simplefs_sb_info *sbi = SIMPLEFS_SB(sb);
-    struct simplefs_inode_info *ci_dest = SIMPLEFS_INODE(dest_dir);
     struct inode *src_in = d_inode(src_dentry);
-    struct buffer_head *bh_fei_blk_src = NULL, *bh_fei_blk_dest = NULL,
-                       *bh_ext = NULL, *dest_bh_ext = NULL;
+    struct buffer_head *src_ei_bh = NULL, *dest_ei_bh = NULL, *src_bi_bh = NULL,
+                       *dest_bi_bh = NULL;
     struct simplefs_file_ei_block *eblk_src = NULL, *eblk_dest = NULL;
     struct simplefs_dir_block *dblock = NULL;
 
@@ -936,14 +902,9 @@ static int simplefs_rename(struct inode *src_dir,
     if (strlen(dest_dentry->d_name.name) >= SIMPLEFS_FILENAME_LEN)
         return -ENAMETOOLONG;
 
-    /* Fail if dest_dentry exists or if dest_dir is full */
-    bh_fei_blk_dest = sb_bread(sb, ci_dest->ei_block);
-    if (!bh_fei_blk_dest)
-        return -EIO;
-
-    eblk_dest = (struct simplefs_file_ei_block *) bh_fei_blk_dest->b_data;
     /* Search for the file in directory */
-    chk = __file_lookup(dest_dir, dest_dentry, &dest_ei, &bi, &fi);
+    chk = __file_lookup(dest_dir, dest_dentry, &dest_ei, &bi, &fi, &dest_ei_bh,
+                        &dest_bi_bh);
     if (chk != -ENOENT) {
         if (chk == 0) { /* found, return exist */
             ret = -EEXIST;
@@ -953,31 +914,29 @@ static int simplefs_rename(struct inode *src_dir,
         goto release_new;
     }
 
+    RELEASE_BUFFER_HEAD(dest_bi_bh); /* dest_bi_bh is not used */
+    eblk_dest = (struct simplefs_file_ei_block *) dest_ei_bh->b_data;
+
     if (dest_dir != src_dir && eblk_dest->nr_files == SIMPLEFS_MAX_SUBFILES) {
         ret = -EMLINK;
         goto release_new;
     }
     if (dest_dir == src_dir && eblk_dest->nr_files == SIMPLEFS_MAX_SUBFILES) {
-        chk = __file_lookup(src_dir, src_dentry, &src_ei, &bi, &fi);
+        chk = __file_lookup(src_dir, src_dentry, &src_ei, &bi, &fi, &src_ei_bh,
+                            &src_bi_bh);
         if (chk != 0) {
             ret = chk;
             goto release_new;
         }
 
-        bh_ext = sb_bread(sb, eblk_dest->extents[src_ei].ee_start + bi);
-        if (!bh_ext) {
-            ret = -EIO;
-            goto release_new;
-        }
-        dblock = (struct simplefs_dir_block *) bh_ext->b_data;
+        dblock = (struct simplefs_dir_block *) src_bi_bh->b_data;
 
         strncpy(dblock->files[fi].filename, dest_dentry->d_name.name,
                 SIMPLEFS_FILENAME_LEN - 1);
         dblock->files[fi].filename[SIMPLEFS_FILENAME_LEN - 1] = '\0';
-        mark_buffer_dirty(bh_ext);
+        mark_buffer_dirty(src_bi_bh);
 
-        brelse(bh_ext);
-        bh_ext = NULL;
+        RELEASE_BUFFER_HEAD(src_bi_bh);
         goto update_metadata;
     }
 
@@ -999,19 +958,19 @@ static int simplefs_rename(struct inode *src_dir,
             ret = -EIO;
             goto release_new;
         }
-        mark_buffer_dirty(bh_fei_blk_dest);
+        mark_buffer_dirty(dest_ei_bh);
         new_pos = 1;
     }
     /* copy src info into new directory */
     bi = hash_code % eblk_dest->extents[dest_ei].ee_len;
     for (idx = 0; idx < eblk_dest->extents[dest_ei].ee_len; bi++, idx++) {
         CHECK_AND_SET_RING_INDEX(bi, eblk_dest->extents[dest_ei].ee_len);
-        dest_bh_ext = sb_bread(sb, eblk_dest->extents[dest_ei].ee_start + bi);
-        if (!dest_bh_ext) {
+        dest_bi_bh = sb_bread(sb, eblk_dest->extents[dest_ei].ee_start + bi);
+        if (!dest_bi_bh) {
             ret = -EIO;
             goto put_block;
         }
-        dblock = (struct simplefs_dir_block *) dest_bh_ext->b_data;
+        dblock = (struct simplefs_dir_block *) dest_bi_bh->b_data;
 
         /* check if dir block is full*/
         if (dblock->nr_files != SIMPLEFS_FILES_PER_BLOCK) {
@@ -1019,16 +978,16 @@ static int simplefs_rename(struct inode *src_dir,
                                        dest_dentry->d_name.name);
             eblk_dest->extents[dest_ei].nr_files++;
             eblk_dest->nr_files++;
-            mark_buffer_dirty(dest_bh_ext);
-            mark_buffer_dirty(bh_fei_blk_dest);
+            mark_buffer_dirty(dest_bi_bh);
+            mark_buffer_dirty(dest_ei_bh);
             /* Track that we inserted the file for cleanup on error */
             dest_inserted = 1;
-            /* Hold dest_bh_ext until the source is removed successfully or
+            /* Hold dest_bi_bh until the source is removed successfully or
              * the operation is rolled back.
              */
             break;
         }
-        brelse(dest_bh_ext);
+        RELEASE_BUFFER_HEAD(dest_bi_bh);
     }
 
     if (!dest_inserted) {
@@ -1037,17 +996,16 @@ static int simplefs_rename(struct inode *src_dir,
     }
 
     /* remove target from old parent directory */
-    ret =
-        simplefs_remove_from_dir(src_dir, src_dentry, &src_ei, &bh_fei_blk_src);
+    ret = simplefs_remove_from_dir(src_dir, src_dentry, &src_ei, &src_ei_bh);
     if (ret != 0)
         goto rm_new;
 
-    eblk_src = (struct simplefs_file_ei_block *) bh_fei_blk_src->b_data;
+    eblk_src = (struct simplefs_file_ei_block *) src_ei_bh->b_data;
     if (!eblk_src->extents[src_ei].nr_files) {
         put_blocks(sbi, eblk_src->extents[src_ei].ee_start,
                    eblk_src->extents[src_ei].ee_len);
         memset(&eblk_src->extents[src_ei], 0, sizeof(struct simplefs_extent));
-        mark_buffer_dirty(bh_fei_blk_src);
+        mark_buffer_dirty(src_ei_bh);
     }
 
 update_metadata:
@@ -1088,18 +1046,17 @@ rm_new:
     /* dest_dentry has no inode; undo insert without simplefs_remove_from_dir */
     if (dest_inserted) {
         /* Use the held directory block buffer to remove the inserted entry */
-        dblock = (struct simplefs_dir_block *) dest_bh_ext->b_data;
+        dblock = (struct simplefs_dir_block *) dest_bi_bh->b_data;
         if (simplefs_try_remove_entry(dblock, eblk_dest, dest_ei, src_in->i_ino,
                                       dest_dentry->d_name.name)) {
-            mark_buffer_dirty(dest_bh_ext);
-            mark_buffer_dirty(bh_fei_blk_dest);
+            mark_buffer_dirty(dest_bi_bh);
+            mark_buffer_dirty(dest_ei_bh);
         } else { /* this should never happen */
             pr_warn(
                 "simplefs: failed to remove inserted entry on rename rollback "
                 "(leak)\n");
         }
-        brelse(dest_bh_ext);
-        dest_bh_ext = NULL;
+        RELEASE_BUFFER_HEAD(dest_bi_bh);
     }
 
 put_block:
@@ -1110,9 +1067,10 @@ put_block:
     }
 
 release_new:
-    brelse(bh_fei_blk_dest);
-    brelse(bh_fei_blk_src);
-    brelse(dest_bh_ext);
+    RELEASE_BUFFER_HEAD(dest_ei_bh);
+    RELEASE_BUFFER_HEAD(src_ei_bh);
+    RELEASE_BUFFER_HEAD(dest_bi_bh);
+    RELEASE_BUFFER_HEAD(src_bi_bh);
     return ret;
 }
 
@@ -1167,10 +1125,10 @@ static int simplefs_rmdir(struct inode *dir, struct dentry *dentry)
 
     eblock = (struct simplefs_file_ei_block *) bh->b_data;
     if (eblock->nr_files != 0) {
-        brelse(bh);
+        RELEASE_BUFFER_HEAD(bh);
         return -ENOTEMPTY;
     }
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh);
 
     /* Remove directory with unlink */
     return simplefs_unlink(dir, dentry);
@@ -1242,7 +1200,7 @@ static int simplefs_link(struct dentry *src_dentry,
         if (dblock->nr_files != SIMPLEFS_FILES_PER_BLOCK)
             break;
         else
-            brelse(bh2);
+            RELEASE_BUFFER_HEAD(bh2);
     }
 
     /* write the file info into simplefs_dir_block */
@@ -1251,8 +1209,8 @@ static int simplefs_link(struct dentry *src_dentry,
     eblock->nr_files++;
     mark_buffer_dirty(bh2);
     mark_buffer_dirty(bh);
-    brelse(bh2);
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh2);
+    RELEASE_BUFFER_HEAD(bh);
 
     inode_inc_link_count(old_inode);
     ihold(old_inode);
@@ -1266,7 +1224,7 @@ put_block:
         memset(&eblock->extents[avail], 0, sizeof(struct simplefs_extent));
     }
 end:
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh);
     return ret;
 }
 
@@ -1359,7 +1317,7 @@ static int simplefs_symlink(struct inode *dir,
         if (dblock->nr_files != SIMPLEFS_FILES_PER_BLOCK)
             break;
         else
-            brelse(bh2);
+            RELEASE_BUFFER_HEAD(bh2);
     }
 
     /* write the file info into simplefs_dir_block */
@@ -1369,8 +1327,8 @@ static int simplefs_symlink(struct inode *dir,
     eblock->nr_files++;
     mark_buffer_dirty(bh2);
     mark_buffer_dirty(bh);
-    brelse(bh2);
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh2);
+    RELEASE_BUFFER_HEAD(bh);
 
     inode->i_link = (char *) ci->i_data;
     memcpy(inode->i_link, symname, l);
@@ -1389,7 +1347,7 @@ iput:
     put_blocks(SIMPLEFS_SB(sb), ci->ei_block, 1);
     put_inode(SIMPLEFS_SB(sb), inode->i_ino);
     iput(inode);
-    brelse(bh);
+    RELEASE_BUFFER_HEAD(bh);
     return ret;
 }
 

--- a/simplefs.h
+++ b/simplefs.h
@@ -119,6 +119,9 @@ struct dentry *simplefs_mount(struct file_system_type *fs_type,
                               const char *dev_name,
                               void *data);
 
+/* hash.c */
+uint32_t simplefs_hash(struct dentry *dentry);
+
 /* file functions */
 extern const struct file_operations simplefs_file_ops;
 extern const struct file_operations simplefs_dir_ops;


### PR DESCRIPTION
Previously, SimpleFS used a sequential insertion method to create files, which worked efficiently when the filesystem contained only a small number of files.
However, in real-world use cases, filesystems often manage a large number of files, making sequential search and insertion inefficient.
Inspired by Ext4’s hash-based directory indexing, this change adopts a hash function to accelerate file indexing and improve scalability.

Change:
Implemented hash-based file index lookup
Improved scalability for large directory structures

hash_code = file_hash(file_name);

extent index = hash_code / SIMPLEFS_MAX_BLOCKS_PER_EXTENT
block index = hash_code % SIMPLEFS_MAX_BLOCKS_PER_EXTENT;
```
 inode
  +-----------------------+
  | i_mode = IFDIR | 0755 |      block 123 (simplefs_file_ei_block)
  | ei_block = 123    ----|--->  +----------------+
  | i_size = 4 KiB        |      | nr_files  = 7  |
  | i_blocks = 1          |      |----------------|
  +-----------------------+    0 | ee_block  = 0  |
              (extent index = 0) | ee_len    = 8  |
                                 | ee_start  = 84 |--->  +-------------+ block 84(simplefs_dir_block)
                                 | nr_file   = 2  |      |nr_files = 2 | (block index = 0)
                                 |----------------|      |-------------|
                               1 | ee_block  = 8  |    0 | inode  = 24 |
              (extent index = 1) | ee_len    = 8  |      | nr_blk = 1  |
                                 | ee_start  = 16 |      | (foo)       |
                                 | nr_file   = 5  |      |-------------|
                                 |----------------|    1 | inode  = 45 |
                                 | ...            |      | nr_blk = 14 |
                                 |----------------|      | (bar)       |
                             341 | ee_block  = 0  |      |-------------|
            (extent index = 341) | ee_len    = 0  |      | ...         |
                                 | ee_start  = 0  |      |-------------|
                                 | nr_file   = 12 |   14 | 0           |
                                 +----------------+      +-------------+ block 85(simplefs_dir_block)
                                                         |nr_files = 2 | (block index = 1)
                                                         |-------------|
                                                       0 | inode  = 48 |
                                                         | nr_blk = 15 |
                                                         | (foo1)      |
                                                         |-------------|
                                                       1 | inode  = 0  |
                                                         | nr_blk = 0  |
                                                         |             |
                                                         |-------------|
                                                         | ...         |
                                                         |-------------|
                                                      14 | 0           |
                                                         +-------------+
```
Performance test

* Random create 30600 files into filesystem

legacy:
```
         168140.12 msec task-clock                       #    0.647 CPUs utilized
            111367      context-switches                 #  662.346 /sec
             40917      cpu-migrations                   #  243.351 /sec
           3736053      page-faults                      #   22.220 K/sec
      369091680702      cycles                           #    2.195 GHz
      168751830643      instructions                     #    0.46  insn per cycle
       34044524391      branches                         #  202.477 M/sec
         768151711      branch-misses                    #    2.26% of all branches

     259.842753513 seconds time elapsed
      23.000247000 seconds user
     150.380145000 seconds sys
```

full_name_hash
```
         167926.13 msec task-clock                       #    0.755 CPUs utilized
            110631      context-switches                 #  658.808 /sec
             43835      cpu-migrations                   #  261.037 /sec
           3858617      page-faults                      #   22.978 K/sec
      392878398961      cycles                           #    2.340 GHz
      207287412692      instructions                     #    0.53  insn per cycle
       42556269864      branches                         #  253.423 M/sec
         840868990      branch-misses                    #    1.98% of all branches

     222.274028604 seconds time elapsed
      20.794966000 seconds user
     151.941876000 seconds sys
```

--------
* Random remove 30600 files into filesystem

legacy:
```
         104332.44 msec task-clock                       #    0.976 CPUs utilized
             56514      context-switches                 #  541.672 /sec
              1174      cpu-migrations                   #   11.252 /sec
           3796962      page-faults                      #   36.393 K/sec
      258293481279      cycles                           #    2.476 GHz
      153853176926      instructions                     #    0.60  insn per cycle
       30434271757      branches                         #  291.705 M/sec
         532967347      branch-misses                    #    1.75% of all branches

     106.921706288 seconds time elapsed
      16.987883000 seconds user
      91.268661000 seconds sys
```

full_name_hash
```
          83278.61 msec task-clock                       #    0.967 CPUs utilized
             52431      context-switches                 #  629.585 /sec
              1309      cpu-migrations                   #   15.718 /sec
           3796501      page-faults                      #   45.588 K/sec
      199894058328      cycles                           #    2.400 GHz
      110625460371      instructions                     #    0.55  insn per cycle
       20325767251      branches                         #  244.069 M/sec
         490549944      branch-misses                    #    2.41% of all branches

      86.132655220 seconds time elapsed
      19.180209000 seconds user
      68.476075000 seconds sys
```

* Random check (ls -la filename) 30600 files into filesystem
Use perf stat ls -la <filename> to measure the query time for each file and sum up all elapsed times to calculate the total lookup cost.

Legacy :
min time: 0.00171 s
max time: 0.03799 s
avg time: 0.00423332 s
tot time: 129.539510 s

full_name_hash:
min time: 0.00171 s
max time: 0.03588 s
avg time: 0.00305601 s
tot time: 93.514040 s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched SimpleFS to hash-based directory indexing using a deterministic FNV-1a `simplefs_hash` to map filenames to extent/block slots, speeding up create/lookup/delete and readdir. On 30.6k files: create ~15% faster, delete ~19% faster, lookup ~28% faster; adds `mkfs.simplefs` support and CI on macOS.

- **New Features**
  - Hash-guided placement and lookup in create/link/symlink/rename/unlink with ring-scan wrap-around; fast `__file_lookup` shared by lookup/rename.
  - Faster traversal and cleanup: iterator skips fully scanned extents/blocks using `nr_files`; unlink/rename free empty directory extents; same-dir rename updates in place, cross-dir rename inserts then rolls back on failure.

- **Refactors and Fixes**
  - Added `hash.c` (FNV-1a with 64→32-bit fold) and utility macros (`CHECK_AND_SET_RING_INDEX`, `RELEASE_BUFFER_HEAD`); streamlined inode cache and allocation checks; clearer variable names; Makefile includes `hash.o`.
  - Fixed `simplefs_lookup` to scan all live entries (skip holes, bound by `SIMPLEFS_FILES_PER_BLOCK`); enforce filename max 254 chars (reserve NUL) and updated README.

<sup>Written for commit 22ee9e2c447d4b2d1b8ea2251cd4d5717911c7dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





















