### PR TITLE
Fix high-severity bugs

### DIFF
--- a/bitmap.h
+++ b/bitmap.h
@@ -57,8 +57,10 @@ static inline uint32_t get_free_blocks(struct super_block *sb, uint32_t len)
         bh = sb_bread(sb, ret + i);
         if (!bh) {
             pr_err("get_free_blocks: sb_bread failed for block %d\n", ret + i);
+            /* Restore all len blocks - bitmap was cleared atomically */
+            bitmap_set(sbi->bfree_bitmap, ret, len);
             sbi->nr_free_blocks += len;
-            return -EIO;
+            return 0; /* Return 0 to indicate failure (0 is reserved) */
         }
         memset(bh->b_data, 0, SIMPLEFS_BLOCK_SIZE);
         mark_buffer_dirty(bh);


### PR DESCRIPTION
Bug fixes:
- bitmap.h: Return 0 instead of -EIO on sb_bread failure (type mismatch) Also restore bitmap and block count on allocation failure
- inode.c: Fix buffer leak in simplefs_lookup() - release bh on error
- inode.c: Initialize fi variable and use explicit indices in simplefs_set_file_into_dir() to prevent undefined behavior
- inode.c: Add null termination after strncpy for filenames
- inode.c: Add bounds validation for extent avail index in simplefs_create(), simplefs_link(), and simplefs_symlink()
- inode.c: Add missing extent nr_files increment in link/symlink

In addition, this commit adds Linux 6.15+ compatibility.
- Update write_begin() signature (kiocb-based API)
- Update write_end() signature and file reference access
- Conditionally exclude writepage from aops (deprecated)
- Update simplefs_mkdir() to return 'struct dentry *'







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes high-severity SimpleFS bugs that could leak buffers, corrupt directory entries, or mis-handle block allocation. Adds Linux 6.15+ compatibility for write paths and mkdir to keep builds green and runtime stable.

- **Bug Fixes**
  - Allocation: on sb_bread failure, restore bitmap and free-block count, and return 0 (reserved) instead of -EIO.
  - simplefs_lookup: release buffer on error to avoid a leak.
  - Directory entries: initialize indices and null-terminate filenames after strncpy to prevent undefined behavior.
  - Extents: validate avail index in create/link/symlink and increment extent nr_files in link/symlink.

- **Compatibility**
  - Update write_begin/write_end to 6.15+ kiocb signatures, adjust inode/file access, and keep older branches; add space checks before block_write_begin.
  - Drop writepage from aops on 6.15+ (deprecated).
  - simplefs_mkdir returns struct dentry* on 6.15+.

<sup>Written for commit fe5f56b955b2bec02ab82e98efaea7b496853ad8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







