### PR TITLE
Support mkfs.simplefs on macOS

### DIFF
--- a/.ci/test-mkfs-macos.sh
+++ b/.ci/test-mkfs-macos.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+IMAGE=test.img
+IMAGESIZE=50
+MKFS=mkfs.simplefs
+
+function build_mkfs()
+{
+    make $MKFS
+}
+
+function test_mkfs()
+{
+    dd if=/dev/zero of=$IMAGE bs=1M count=$IMAGESIZE 2>/dev/null
+    ./$MKFS $IMAGE
+}
+
+build_mkfs
+test_mkfs

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,3 +26,13 @@ jobs:
             .ci/check-newline.sh
             .ci/check-format.sh
         shell: bash
+
+  mkfs_macos:
+    runs-on: macos-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+      - name: test mkfs.simplefs on macOS
+        run: |
+            .ci/test-mkfs-macos.sh
+        shell: bash

--- a/mkfs.c
+++ b/mkfs.c
@@ -1,5 +1,19 @@
+#if !defined(__linux__) && !defined(__APPLE__)
+#error \
+    "Do not manage to build this file unless your platform is Linux or macOS."
+#endif
+
 #include <fcntl.h>
-#include <linux/fs.h>
+#if defined(__linux__)
+#include <linux/fs.h> /* BLKGETSIZE64 */
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#include <sys/disk.h> /* DKIOCGETBLOCKCOUNT and DKIOCGETBLOCKSIZE */
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -278,12 +292,31 @@ int main(int argc, char **argv)
     /* Get block device size */
     if ((stat_buf.st_mode & S_IFMT) == S_IFBLK) {
         long int blk_size = 0;
+#if defined(__linux__)
         ret = ioctl(fd, BLKGETSIZE64, &blk_size);
         if (ret != 0) {
             perror("BLKGETSIZE64:");
             ret = EXIT_FAILURE;
             goto fclose;
         }
+#elif defined(__APPLE__)
+        uint64_t block_count = 0;
+        uint32_t sector_size = 0;
+
+        ret = ioctl(fd, DKIOCGETBLOCKCOUNT, &block_count);
+        if (ret) {
+            perror("DKIOCGETBLOCKCOUNT");
+            ret = EXIT_FAILURE;
+            goto fclose;
+        }
+        ret = ioctl(fd, DKIOCGETBLOCKSIZE, &sector_size);
+        if (ret) {
+            perror("DKIOCGETBLOCKSIZE");
+            ret = EXIT_FAILURE;
+            goto fclose;
+        }
+        blk_size = block_count * sector_size;
+#endif
         stat_buf.st_size = blk_size;
     }
 


### PR DESCRIPTION
Fixes [issue#78](https://github.com/sysprog21/simplefs/issues/78) with enabling `mkfs.simplefs` to be compiled and executed on macOS. Currently, the utility depends on Linux-specific headers and `ioctl` operations, which prevents the `rv32emu` CI from running `simplefs` test cases on macOS runners.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable mkfs.simplefs to build and run on macOS by adding platform-specific headers, endian helpers, and block device size detection. This unblocks running simplefs tests on macOS runners while keeping Linux behavior unchanged.

- **New Features**
  - Add conditional includes for Linux and macOS; define htole/le macros via OSSwap* on macOS.
  - Implement macOS block device size detection using DKIOCGETBLOCKCOUNT and DKIOCGETBLOCKSIZE.
  - Retain Linux path using BLKGETSIZE64; no CLI or usage changes.
  - Add a macOS CI job that builds mkfs.simplefs and formats a test image.

<sup>Written for commit 1889a19e7b767d77fed4eccbcc1ac6036f8e7a40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



