### PR TITLE
Fix missing entries in simplefs_lookup

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -151,21 +151,21 @@ static struct dentry *simplefs_lookup(struct inode *dir,
                 return ERR_PTR(-EIO);
 
             dblock = (struct simplefs_dir_block *) bh2->b_data;
-
+            int nr_files = dblock->nr_files;
             /* Search file in ei_block */
-            for (fi = 0; fi < dblock->nr_files;) {
+            for (fi = 0; nr_files && fi < SIMPLEFS_FILES_PER_BLOCK;) {
                 f = &dblock->files[fi];
-                if (!f->inode) {
-                    brelse(bh2);
-                    goto search_end;
+
+                if (f->inode) {
+                    nr_files--;
+                    if (!strncmp(f->filename, dentry->d_name.name,
+                                 SIMPLEFS_FILENAME_LEN)) {
+                        inode = simplefs_iget(sb, f->inode);
+                        brelse(bh2);
+                        goto search_end;
+                    }
                 }
-                if (!strncmp(f->filename, dentry->d_name.name,
-                             SIMPLEFS_FILENAME_LEN)) {
-                    inode = simplefs_iget(sb, f->inode);
-                    brelse(bh2);
-                    goto search_end;
-                }
-                fi += dblock->files[fi].nr_blk;
+                fi += f->nr_blk;
             }
             brelse(bh2);
             bh2 = NULL;


### PR DESCRIPTION
simplefs_lookup must scan all entries in a directory before it can determine whether a file exists.

The current implementation stops early when it encounters a hole in the directory, which can cause later files to be missed. In addition, fi is used as the index into dblock, so the loop should be bounded by SIMPLEFS_FILES_PER_BLOCK rather than dblock->nr_files. If a file is located near the end of the directory block, the loop may terminate early when fi >= dblock->nr_files, resulting in an incomplete scan.

Fix this by skipping holes during filename comparison and continuing to advance fi until all live directory entries have been examined.

This issue can be reproduced with a freshly formatted simplefs image using
the following steps.
### Before this patch
```bash
$ sudo touch test/{1..10}.txt
$ sudo rm test/1.txt
$ echo 3 | sudo tee /proc/sys/vm/drop_caches
$ sudo touch test/9.txt
$ ls test/
10.txt  2.txt  3.txt  4.txt  5.txt  6.txt  7.txt  8.txt  9.txt  9.txt
```
### After this patch
```bash
$ sudo touch test/{1..10}.txt
$ sudo rm test/1.txt
$ echo 3 | sudo tee /proc/sys/vm/drop_caches
$ sudo touch test/9.txt
$ ls test/
10.txt  2.txt  3.txt  4.txt  5.txt  6.txt  7.txt  8.txt  9.txt 
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `simplefs_lookup` scans the whole directory block and skips holes so files aren’t missed, including entries near the end. This fixes false “not found” results and eliminates duplicate-looking listings after deletions.

- **Bug Fixes**
  - Continue scanning across holes; compare names only when `f->inode` is set.
  - Bound the loop by `SIMPLEFS_FILES_PER_BLOCK` and track live entries with a local `nr_files`.
  - Advance with `fi += f->nr_blk` to correctly traverse sparse directory blocks.

<sup>Written for commit f85250ad8b941d8bfb91bd1ec71254de8df5e741. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

