### PR TITLE
Support for linux 6.18 and up

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -1,11 +1,27 @@
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+#include "simplefs.h"
 
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+#include <linux/fs_context.h>
+#endif
 #include <linux/fs.h>
 #include <linux/kernel.h>
 #include <linux/module.h>
 
-#include "simplefs.h"
 
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+static int simplefs_get_tree(struct fs_context *fc)
+{
+	 return get_tree_bdev(fc, simplefs_fill_super);
+}
+static const struct fs_context_operations simplefs_context_ops = {
+	.get_tree	= simplefs_get_tree,
+};
+static int init_simplefs_context(struct fs_context *fc) {
+    fc->ops = &simplefs_context_ops;
+    return 0;
+}
+#else
 /* Mount a simplefs partition */
 struct dentry *simplefs_mount(struct file_system_type *fs_type,
                               int flags,
@@ -21,7 +37,7 @@ struct dentry *simplefs_mount(struct file_system_type *fs_type,
 
     return dentry;
 }
-
+#endif
 /* Unmount a simplefs partition */
 void simplefs_kill_sb(struct super_block *sb)
 {
@@ -41,7 +57,11 @@ void simplefs_kill_sb(struct super_block *sb)
 static struct file_system_type simplefs_file_system_type = {
     .owner = THIS_MODULE,
     .name = "simplefs",
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+    .init_fs_context = init_simplefs_context,
+#else
     .mount = simplefs_mount,
+#endif
     .kill_sb = simplefs_kill_sb,
     .fs_flags = FS_REQUIRES_DEV,
     .next = NULL,

--- a/fs.c
+++ b/fs.c
@@ -12,12 +12,13 @@
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
 static int simplefs_get_tree(struct fs_context *fc)
 {
-	 return get_tree_bdev(fc, simplefs_fill_super);
+    return get_tree_bdev(fc, simplefs_fill_super);
 }
 static const struct fs_context_operations simplefs_context_ops = {
-	.get_tree	= simplefs_get_tree,
+    .get_tree = simplefs_get_tree,
 };
-static int init_simplefs_context(struct fs_context *fc) {
+static int init_simplefs_context(struct fs_context *fc)
+{
     fc->ops = &simplefs_context_ops;
     return 0;
 }

--- a/inode.c
+++ b/inode.c
@@ -41,7 +41,13 @@ struct inode *simplefs_iget(struct super_block *sb, unsigned long ino)
         return ERR_PTR(-ENOMEM);
 
     /* If inode is in cache, return it */
+#if SIMPLEFS_AT_LEAST(6, 19, 0)
+    if (!(inode_state_read_once(inode) & I_NEW)) 
+    /*inode->i_state is struct inode_state_flags in kernels v6.19+,
+    and inode_state_read_once returns __state from the state flag structure which is enum*/
+#else
     if (!(inode->i_state & I_NEW))
+#endif
         return inode;
 
     ci = SIMPLEFS_INODE(inode);

--- a/inode.c
+++ b/inode.c
@@ -42,11 +42,11 @@ struct inode *simplefs_iget(struct super_block *sb, unsigned long ino)
 
     /* If inode is in cache, return it */
 #if SIMPLEFS_AT_LEAST(6, 19, 0)
-    if (!(inode_state_read_once(inode) & I_NEW)) 
-    /*
-     * inode->i_state is struct inode_state_flags in kernels v6.19+,
-     * and inode_state_read_once returns __state from the state flag structure which is enum
-     */
+    if (!(inode_state_read_once(inode) & I_NEW))
+/* inode->i_state is struct inode_state_flags in kernels v6.19 +,
+ * and inode_state_read_once returns __state from the state flag
+ * structure which is enum
+ */
 #else
     if (!(inode->i_state & I_NEW))
 #endif
@@ -671,7 +671,7 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
     if (S_ISLNK(inode->i_mode))
         goto clean_inode;
 
-        /* Update inode stats */
+    /* Update inode stats */
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
     simple_inode_init_ts(dir);
 #elif SIMPLEFS_AT_LEAST(6, 6, 0)
@@ -915,7 +915,7 @@ static int simplefs_rename(struct inode *old_dir,
     if (ret != 0)
         goto release_new;
 
-        /* Update old parent inode metadata */
+    /* Update old parent inode metadata */
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
     simple_inode_init_ts(old_dir);
 #elif SIMPLEFS_AT_LEAST(6, 6, 0)

--- a/inode.c
+++ b/inode.c
@@ -43,8 +43,10 @@ struct inode *simplefs_iget(struct super_block *sb, unsigned long ino)
     /* If inode is in cache, return it */
 #if SIMPLEFS_AT_LEAST(6, 19, 0)
     if (!(inode_state_read_once(inode) & I_NEW)) 
-    /*inode->i_state is struct inode_state_flags in kernels v6.19+,
-    and inode_state_read_once returns __state from the state flag structure which is enum*/
+    /*
+     * inode->i_state is struct inode_state_flags in kernels v6.19+,
+     * and inode_state_read_once returns __state from the state flag structure which is enum
+     */
 #else
     if (!(inode->i_state & I_NEW))
 #endif

--- a/inode.c
+++ b/inode.c
@@ -40,7 +40,7 @@ struct inode *simplefs_iget(struct super_block *sb, unsigned long ino)
     if (!inode)
         return ERR_PTR(-ENOMEM);
 
-    /* If inode is in cache, return it */
+        /* If inode is in cache, return it */
 #if SIMPLEFS_AT_LEAST(6, 19, 0)
     if (!(inode_state_read_once(inode) & I_NEW))
 /* inode->i_state is struct inode_state_flags in kernels v6.19 +,
@@ -671,7 +671,7 @@ static int simplefs_unlink(struct inode *dir, struct dentry *dentry)
     if (S_ISLNK(inode->i_mode))
         goto clean_inode;
 
-    /* Update inode stats */
+        /* Update inode stats */
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
     simple_inode_init_ts(dir);
 #elif SIMPLEFS_AT_LEAST(6, 6, 0)
@@ -915,7 +915,7 @@ static int simplefs_rename(struct inode *old_dir,
     if (ret != 0)
         goto release_new;
 
-    /* Update old parent inode metadata */
+        /* Update old parent inode metadata */
 #if SIMPLEFS_AT_LEAST(6, 7, 0)
     simple_inode_init_ts(old_dir);
 #elif SIMPLEFS_AT_LEAST(6, 6, 0)

--- a/mkfs.c
+++ b/mkfs.c
@@ -61,7 +61,7 @@ static struct superblock *write_superblock(int fd, struct stat *fstats)
         nr_blocks - nr_istore_blocks - nr_ifree_blocks - nr_bfree_blocks;
 
     memset(sb, 0, sizeof(struct superblock));
-    sb->info = (struct simplefs_sb_info){
+    sb->info = (struct simplefs_sb_info) {
         .magic = htole32(SIMPLEFS_MAGIC),
         .nr_blocks = htole32(nr_blocks),
         .nr_inodes = htole32(nr_inodes),

--- a/mkfs.c
+++ b/mkfs.c
@@ -61,7 +61,7 @@ static struct superblock *write_superblock(int fd, struct stat *fstats)
         nr_blocks - nr_istore_blocks - nr_ifree_blocks - nr_bfree_blocks;
 
     memset(sb, 0, sizeof(struct superblock));
-    sb->info = (struct simplefs_sb_info) {
+    sb->info = (struct simplefs_sb_info){
         .magic = htole32(SIMPLEFS_MAGIC),
         .nr_blocks = htole32(nr_blocks),
         .nr_inodes = htole32(nr_inodes),

--- a/simplefs.h
+++ b/simplefs.h
@@ -101,7 +101,11 @@ struct simplefs_dir_block {
 };
 
 /* superblock functions */
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+int simplefs_fill_super(struct super_block *sb, struct fs_context *fc);
+#else
 int simplefs_fill_super(struct super_block *sb, void *data, int silent);
+#endif
 void simplefs_kill_sb(struct super_block *sb);
 
 /* inode functions */

--- a/super.c
+++ b/super.c
@@ -650,7 +650,7 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent)
         ret = -ENOMEM;
         goto iput;
     }
-//Since parse_options is not available at fill_super stage at kernels v6.18+, it is disabled for now.
+/* Since parse_options is not available at fill_super stage at kernels v6.18+, it is disabled for now. */
 #if SIMPLEFS_LESS_EQUAL(6, 17, 0)
     ret = simplefs_parse_options(sb, data);
     if (ret) {

--- a/super.c
+++ b/super.c
@@ -13,7 +13,9 @@
 #include <linux/parser.h>
 
 #include "simplefs.h"
-
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+#include <linux/fs_context.h>
+#endif
 struct dentry *simplefs_mount(struct file_system_type *fs_type,
                               int flags,
                               const char *dev_name,
@@ -529,12 +531,17 @@ static struct super_operations simplefs_super_ops = {
 };
 
 /* Fill the struct superblock from partition superblock */
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+int simplefs_fill_super(struct super_block *sb, struct fs_context *fc)
+#else
 int simplefs_fill_super(struct super_block *sb, void *data, int silent)
+#endif
 {
     struct buffer_head *bh = NULL;
     struct simplefs_sb_info *csb = NULL;
     struct simplefs_sb_info *sbi = NULL;
     struct inode *root_inode = NULL;
+
     int ret = 0, i;
 
     /* Initialize the superblock */
@@ -643,14 +650,15 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent)
         ret = -ENOMEM;
         goto iput;
     }
-
+//Since parse_options is not available at fill_super stage at kernels v6.18+, it is disabled for now.
+#if SIMPLEFS_LESS_EQUAL(6, 17, 0)
     ret = simplefs_parse_options(sb, data);
     if (ret) {
         pr_err("simplefs_fill_super: Failed to parse options, error code: %d\n",
                ret);
         return ret;
     }
-
+#endif
     return 0;
 
 iput:

--- a/super.c
+++ b/super.c
@@ -533,10 +533,11 @@ static struct super_operations simplefs_super_ops = {
 /* Fill the struct superblock from partition superblock */
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
 int simplefs_fill_super(struct super_block *sb, struct fs_context *fc)
+{
 #else
 int simplefs_fill_super(struct super_block *sb, void *data, int silent)
-#endif
 {
+#endif
     struct buffer_head *bh = NULL;
     struct simplefs_sb_info *csb = NULL;
     struct simplefs_sb_info *sbi = NULL;
@@ -642,7 +643,7 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent)
 #elif SIMPLEFS_AT_LEAST(5, 12, 0)
     inode_init_owner(&init_user_ns, root_inode, NULL, root_inode->i_mode);
 #else
-    inode_init_owner(root_inode, NULL, root_inode->i_mode);
+inode_init_owner(root_inode, NULL, root_inode->i_mode);
 #endif
 
     sb->s_root = d_make_root(root_inode);
@@ -650,7 +651,8 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent)
         ret = -ENOMEM;
         goto iput;
     }
-/* Since parse_options is not available at fill_super stage at kernels v6.18+, it is disabled for now. */
+    /* Since parse_options is not available at fill_super stage at kernels
+     * v6.18+, it is disabled for now. */
 #if SIMPLEFS_LESS_EQUAL(6, 17, 0)
     ret = simplefs_parse_options(sb, data);
     if (ret) {


### PR DESCRIPTION
This commit adds changes to align with the changed linux kernel API in linux kernel 6.18 and up. This commit includes addition of fs_context operations, get_tree, modifications to fill_super, and other related functions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Linux kernel 6.18+ support by moving to the `fs_context` API and updating mount and inode handling. Backward compatible; option parsing is off on 6.18+ for now, and coding style issues are fixed.

- **New Features**
  - Implement `fs_context` path: `get_tree` and `init_fs_context` hook; fallback to `simplefs_mount` on <6.18.
  - Update `fill_super` signature for >=6.18; wire into `get_tree_bdev`.
  - Use `inode_state_read_once` on >=6.19 for the updated `inode_state` layout.
  - Disable `simplefs_parse_options` in `fill_super` on >=6.18; keep parsing on <=6.17.

- **Refactors**
  - Fixed coding style errors and aligned comments/includes; no behavior changes.

<sup>Written for commit e6872af36179fc5db209478f77bdc3a4e22eb2b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

