### PR TITLE
added support for fs_context operations -> parse_param

### DIFF
--- a/fs.c
+++ b/fs.c
@@ -27,7 +27,7 @@ static int init_simplefs_context(struct fs_context *fc)
         return -ENOMEM;
     fc->fs_private = ctx;
     fc->ops = &simplefs_context_ops;
-    
+
     return 0;
 }
 extern const struct fs_parameter_spec simplefs_param_specs;

--- a/fs.c
+++ b/fs.c
@@ -15,7 +15,8 @@ static int simplefs_get_tree(struct fs_context *fc)
 {
     return get_tree_bdev(fc, simplefs_fill_super);
 }
-static void simplefs_free_context(struct fs_context *fc) {
+static void simplefs_free_context(struct fs_context *fc)
+{
     struct simplefs_fs_context *ctx = fc->fs_private;
 
     if (!ctx)

--- a/fs.c
+++ b/fs.c
@@ -23,7 +23,7 @@ static int init_simplefs_context(struct fs_context *fc)
 {
     struct simplefs_fs_context *ctx;
     ctx = kzalloc(sizeof(*ctx), GFP_KERNEL);
-    if(!ctx)
+    if (!ctx)
         return -ENOMEM;
     fc->fs_private = ctx;
     fc->ops = &simplefs_context_ops;

--- a/fs.c
+++ b/fs.c
@@ -3,6 +3,7 @@
 
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
 #include <linux/fs_context.h>
+#include <linux/parser.h>
 #endif
 #include <linux/fs.h>
 #include <linux/kernel.h>
@@ -16,12 +17,20 @@ static int simplefs_get_tree(struct fs_context *fc)
 }
 static const struct fs_context_operations simplefs_context_ops = {
     .get_tree = simplefs_get_tree,
+    .parse_param = simplefs_parse_param,
 };
 static int init_simplefs_context(struct fs_context *fc)
 {
+    struct simplefs_fs_context *ctx;
+    ctx = kzalloc(sizeof(*ctx), GFP_KERNEL);
+    if(!ctx)
+        return -ENOMEM;
+    fc->fs_private = ctx;
     fc->ops = &simplefs_context_ops;
+    
     return 0;
 }
+extern const struct fs_parameter_spec simplefs_param_specs;
 #else
 /* Mount a simplefs partition */
 struct dentry *simplefs_mount(struct file_system_type *fs_type,
@@ -60,6 +69,7 @@ static struct file_system_type simplefs_file_system_type = {
     .name = "simplefs",
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
     .init_fs_context = init_simplefs_context,
+    .parameters = &simplefs_param_specs,
 #else
     .mount = simplefs_mount,
 #endif

--- a/fs.c
+++ b/fs.c
@@ -3,7 +3,7 @@
 
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
 #include <linux/fs_context.h>
-#include <linux/parser.h>
+#include <linux/fs_parser.h>
 #endif
 #include <linux/fs.h>
 #include <linux/kernel.h>
@@ -15,9 +15,19 @@ static int simplefs_get_tree(struct fs_context *fc)
 {
     return get_tree_bdev(fc, simplefs_fill_super);
 }
+static void simplefs_free_context(struct fs_context *fc) {
+    struct simplefs_fs_context *ctx = fc->fs_private;
+
+    if (!ctx)
+        return;
+
+    kfree(ctx->journal_path);
+    kfree(ctx);
+}
 static const struct fs_context_operations simplefs_context_ops = {
     .get_tree = simplefs_get_tree,
     .parse_param = simplefs_parse_param,
+    .free = simplefs_free_context,
 };
 static int init_simplefs_context(struct fs_context *fc)
 {

--- a/simplefs.h
+++ b/simplefs.h
@@ -114,7 +114,7 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent);
 void simplefs_kill_sb(struct super_block *sb);
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
 #include <linux/fs_context.h>
-#include <linux/parser.h>
+#include <linux/fs_parser.h>
 int simplefs_parse_param(struct fs_context *fc, struct fs_parameter *param);
 #endif
 /* inode functions */

--- a/simplefs.h
+++ b/simplefs.h
@@ -113,8 +113,8 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent);
 #endif
 void simplefs_kill_sb(struct super_block *sb);
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
-#include <linux/parser.h>
 #include <linux/fs_context.h>
+#include <linux/parser.h>
 int simplefs_parse_param(struct fs_context *fc, struct fs_parameter *param);
 #endif
 /* inode functions */

--- a/simplefs.h
+++ b/simplefs.h
@@ -99,7 +99,12 @@ struct simplefs_dir_block {
     uint32_t nr_files;
     struct simplefs_file files[SIMPLEFS_FILES_PER_BLOCK];
 };
-
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+struct simplefs_fs_context {
+    u32 journal_dev;
+    char *journal_path;
+};
+#endif
 /* superblock functions */
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
 int simplefs_fill_super(struct super_block *sb, struct fs_context *fc);
@@ -107,7 +112,11 @@ int simplefs_fill_super(struct super_block *sb, struct fs_context *fc);
 int simplefs_fill_super(struct super_block *sb, void *data, int silent);
 #endif
 void simplefs_kill_sb(struct super_block *sb);
-
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+#include <linux/parser.h>
+#include <linux/fs_context.h>
+int simplefs_parse_param(struct fs_context *fc, struct fs_parameter *param);
+#endif
 /* inode functions */
 int simplefs_init_inode_cache(void);
 void simplefs_destroy_inode_cache(void);

--- a/super.c
+++ b/super.c
@@ -530,12 +530,9 @@ static int simplefs_parse_options(struct super_block *sb, char *options)
                 kfree(journal_path);
                 return ret;
             }
-
-            journal_inode = path.dentry->d_inode;
-
-            path_put(&path);
             kfree(journal_path);
 
+            journal_inode = path.dentry->d_inode;
             if (S_ISBLK(journal_inode->i_mode)) {
                 unsigned long journal_devnum =
                     new_encode_dev(journal_inode->i_rdev);
@@ -547,6 +544,7 @@ static int simplefs_parse_options(struct super_block *sb, char *options)
                     return ret;
                 }
             }
+            path_put(&path);
             break;
         }
         }

--- a/super.c
+++ b/super.c
@@ -690,7 +690,7 @@ inode_init_owner(root_inode, NULL, root_inode->i_mode);
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
     if (ctx->journal_dev) {
         ret = simplefs_load_journal(sb, ctx->journal_dev);
-        if(ret) {
+        if (ret) {
             pr_err(
                 "simplefs_parse_options: simplefs_load_journal failed with "
                 "%d\n",

--- a/super.c
+++ b/super.c
@@ -708,6 +708,7 @@ inode_init_owner(root_inode, NULL, root_inode->i_mode);
             return ret;
         }
         inode = d_inode(path.dentry);
+        path_put(&path);
         if (S_ISBLK(inode->i_mode)) {
             unsigned long journal_devnum = new_encode_dev(inode->i_rdev);
             if ((ret = simplefs_load_journal(sb, journal_devnum))) {

--- a/super.c
+++ b/super.c
@@ -477,7 +477,7 @@ int simplefs_parse_param(struct fs_context *fc, struct fs_parameter *param)
             return -ENOMEM;
         break;
     default:
-        return -EINVAL; 
+        return -EINVAL;
     }
     }
     return 0;
@@ -702,9 +702,9 @@ inode_init_owner(root_inode, NULL, root_inode->i_mode);
         struct path path;
         struct inode *inode;
         ret = kern_path(ctx->journal_path, LOOKUP_FOLLOW, &path);
-        if(ret) {
+        if (ret) {
             pr_err("simplefs_parse_options: kern_path failed with error %d\n",
-                  ret);
+                   ret);
             return ret;
         }
         inode = d_inode(path.dentry);

--- a/super.c
+++ b/super.c
@@ -454,18 +454,17 @@ static const match_table_t tokens = {
 const struct fs_parameter_spec simplefs_param_specs[] = {
     fsparam_u32("journal_dev", SIMPLEFS_OPT_JOURNAL_DEV),
     fsparam_string("journal_path", SIMPLEFS_OPT_JOURNAL_PATH),
-    {}
-};
+    {}};
 int simplefs_parse_param(struct fs_context *fc, struct fs_parameter *param)
 {
     struct simplefs_fs_context *ctx = fc->fs_private;
     struct fs_parse_result result;
     int opt;
-    
+
     opt = fs_parse(fc, simplefs_param_specs, param, &result);
     if (opt < 0)
         return opt;
-    
+
     switch (opt) {
     case SIMPLEFS_OPT_JOURNAL_DEV:
         ctx->journal_dev = result.uint_32;
@@ -474,11 +473,11 @@ int simplefs_parse_param(struct fs_context *fc, struct fs_parameter *param)
     case SIMPLEFS_OPT_JOURNAL_PATH: {
         kfree(ctx->journal_path);
         ctx->journal_path = kstrdup(param->string, GFP_KERNEL);
-        if(!ctx->journal_path)
+        if (!ctx->journal_path)
             return -ENOMEM;
         break;
     default:
-        return -EINVAL;    
+        return -EINVAL; 
     }
     }
     return 0;
@@ -689,7 +688,7 @@ inode_init_owner(root_inode, NULL, root_inode->i_mode);
     }
 
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
-    if(ctx->journal_dev) {
+    if (ctx->journal_dev) {
         ret = simplefs_load_journal(sb, ctx->journal_dev);
         if(ret) {
             pr_err(
@@ -699,21 +698,19 @@ inode_init_owner(root_inode, NULL, root_inode->i_mode);
             return ret;
         }
     }
-    if(ctx->journal_path) {
+    if (ctx->journal_path) {
         struct path path;
         struct inode *inode;
         ret = kern_path(ctx->journal_path, LOOKUP_FOLLOW, &path);
         if(ret) {
-            pr_err(
-                "simplefs_parse_options: kern_path failed with error %d\n",
-                ret);
+            pr_err("simplefs_parse_options: kern_path failed with error %d\n",
+                  ret);
             return ret;
         }
         inode = d_inode(path.dentry);
-        if(S_ISBLK(inode->i_mode)) {
-            unsigned long journal_devnum = 
-                new_encode_dev(inode->i_rdev);
-            if((ret = simplefs_load_journal(sb, journal_devnum))) {
+        if (S_ISBLK(inode->i_mode)) {
+            unsigned long journal_devnum = new_encode_dev(inode->i_rdev);
+            if ((ret = simplefs_load_journal(sb, journal_devnum))) {
                 pr_err(
                     "simplefs_parse_options: simplefs_load_journal failed "
                     "with %d\n",

--- a/super.c
+++ b/super.c
@@ -15,6 +15,7 @@
 #include "simplefs.h"
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
 #include <linux/fs_context.h>
+#include <linux/fs_parser.h>
 #endif
 struct dentry *simplefs_mount(struct file_system_type *fs_type,
                               int flags,
@@ -449,6 +450,40 @@ static const match_table_t tokens = {
     {SIMPLEFS_OPT_JOURNAL_DEV, "journal_dev=%u"},
     {SIMPLEFS_OPT_JOURNAL_PATH, "journal_path=%s"},
 };
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+const struct fs_parameter_spec simplefs_param_specs[] = {
+    fsparam_u32("journal_dev", SIMPLEFS_OPT_JOURNAL_DEV),
+    fsparam_string("journal_path", SIMPLEFS_OPT_JOURNAL_PATH),
+    {}
+};
+int simplefs_parse_param(struct fs_context *fc, struct fs_parameter *param)
+{
+    struct simplefs_fs_context *ctx = fc->fs_private;
+    struct fs_parse_result result;
+    int opt;
+    
+    opt = fs_parse(fc, simplefs_param_specs, param, &result);
+    if (opt < 0)
+        return opt;
+    
+    switch (opt) {
+    case SIMPLEFS_OPT_JOURNAL_DEV:
+        ctx->journal_dev = result.uint_32;
+        break;
+
+    case SIMPLEFS_OPT_JOURNAL_PATH: {
+        kfree(ctx->journal_path);
+        ctx->journal_path = kstrdup(param->string, GFP_KERNEL);
+        if(!ctx->journal_path)
+            return -ENOMEM;
+        break;
+    default:
+        return -EINVAL;    
+    }
+    }
+    return 0;
+}
+#else
 static int simplefs_parse_options(struct super_block *sb, char *options)
 {
     substring_t args[MAX_OPT_ARGS];
@@ -520,7 +555,7 @@ static int simplefs_parse_options(struct super_block *sb, char *options)
 
     return 0;
 }
-
+#endif
 static struct super_operations simplefs_super_ops = {
     .put_super = simplefs_put_super,
     .alloc_inode = simplefs_alloc_inode,
@@ -534,6 +569,7 @@ static struct super_operations simplefs_super_ops = {
 #if SIMPLEFS_AT_LEAST(6, 18, 0)
 int simplefs_fill_super(struct super_block *sb, struct fs_context *fc)
 {
+    struct simplefs_fs_context *ctx = fc->fs_private;
 #else
 int simplefs_fill_super(struct super_block *sb, void *data, int silent)
 {
@@ -651,9 +687,42 @@ inode_init_owner(root_inode, NULL, root_inode->i_mode);
         ret = -ENOMEM;
         goto iput;
     }
-    /* Since parse_options is not available at fill_super stage at kernels
-     * v6.18+, it is disabled for now. */
-#if SIMPLEFS_LESS_EQUAL(6, 17, 0)
+
+#if SIMPLEFS_AT_LEAST(6, 18, 0)
+    if(ctx->journal_dev) {
+        ret = simplefs_load_journal(sb, ctx->journal_dev);
+        if(ret) {
+            pr_err(
+                "simplefs_parse_options: simplefs_load_journal failed with "
+                "%d\n",
+                ret);
+            return ret;
+        }
+    }
+    if(ctx->journal_path) {
+        struct path path;
+        struct inode *inode;
+        ret = kern_path(ctx->journal_path, LOOKUP_FOLLOW, &path);
+        if(ret) {
+            pr_err(
+                "simplefs_parse_options: kern_path failed with error %d\n",
+                ret);
+            return ret;
+        }
+        inode = d_inode(path.dentry);
+        if(S_ISBLK(inode->i_mode)) {
+            unsigned long journal_devnum = 
+                new_encode_dev(inode->i_rdev);
+            if((ret = simplefs_load_journal(sb, journal_devnum))) {
+                pr_err(
+                    "simplefs_parse_options: simplefs_load_journal failed "
+                    "with %d\n",
+                    ret);
+                return ret;
+            }
+        }
+    }
+#else
     ret = simplefs_parse_options(sb, data);
     if (ret) {
         pr_err("simplefs_fill_super: Failed to parse options, error code: %d\n",


### PR DESCRIPTION
This commit implements the fs_context_operations->parse_param(replacement for parse_options used at fill_super for kernels below 6.18) and modifies other related functions to work with the newly implemented operation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add fs_context-based mount option parsing for kernels 6.18+, adding `parse_param` for `journal_dev` and `journal_path`, with proper context cleanup and journal loading. Legacy `parse_options` remains for older kernels.

- New Features
  - Implemented `simplefs_parse_param` using `fs_parameter_spec`/`fs_parse` for `journal_dev` (u32) and `journal_path` (string).
  - Added per-mount `simplefs_fs_context`; allocated in `.init_fs_context`, stored in `fc->fs_private`, and exposed via `.parameters = &simplefs_param_specs`.
  - In `simplefs_fill_super` (>=6.18), load the journal from `journal_dev` or resolve `journal_path` with `kern_path` and load if it’s a block device.

- Bug Fixes
  - Added `.free` in `fs_context_operations` to free `journal_path` and the context; free any existing `journal_path` before `kstrdup()` in `parse_param`.
  - Reordered `path_put()` to occur after `d_inode()` extraction (>=6.18) and after device checks in the legacy path to prevent a possible use-after-free.

<sup>Written for commit e60949bb65dbfce8c1b25adf8362a3d4cbbbfd54. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

