### PR TITLE
Fix lookup and overflow in simplefs_ext_search

### DIFF
--- a/extent.c
+++ b/extent.c
@@ -64,9 +64,10 @@ uint32_t simplefs_ext_search(struct simplefs_file_ei_block *index,
      */
     end_block = index->extents[end].ee_block;
     end_len = index->extents[end].ee_len;
-    if (iblock >= end_block && iblock < end_len)
+
+    if (iblock >= end_block && iblock < end_block + end_len)
         return end;
     if (boundary < SIMPLEFS_MAX_EXTENTS)
         return boundary;
-    return boundary;
+    return -1;
 }


### PR DESCRIPTION
The final hit check used 'iblock < end_len' instead of 'iblock < end_block + end_len', so a block in any extent not starting at block 0 was missed and returned as the unused 'boundary' slot (read as a hole, or overwritten on write).

Also, return -1 when the extent array is full, instead of returning the out-of-bounds, SIMPLEFS_MAX_EXTENTS

Actually, this code is never executed: simplefs_ext_search is only reachable through simplefs_file_get_block, which is wired into the page-cache aops (readahead/readpage/write_begin). Since read()/write() on master don't use the page cache at all, the buggy function is effectively dead code.

So if we really want to test this code, we can use "readahead" to reach it.

Here is an example:

1. Create a file larger than 8*4096 bytes, e.g.:
```
head -c 36864 /dev/zero | tr '\0' 'A' | sudo tee data.test >/dev/null
```
2. Use this code to read it:
```
#define _GNU_SOURCE
#include <fcntl.h>
#include <sys/stat.h>
#include <unistd.h>

int main(int argc, char **argv)
{
    int fd = open(argv[1], O_RDONLY);
    struct stat st;
    fstat(fd, &st);
    readahead(fd, 0, st.st_size);
    close(fd);
    return 0;
}
```

Close #76


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix extent lookup and overflow in `simplefs_ext_search` to correctly match blocks within extents and avoid out-of-bounds indices. Prevents false holes and unintended overwrites. Fixes #76.

- **Bug Fixes**
  - Use `iblock < end_block + end_len` to check final hit, instead of `iblock < end_len`.
  - Return `-1` when the extent array is full, instead of `SIMPLEFS_MAX_EXTENTS`.

<sup>Written for commit 8895361e5b5e1189412f1e545ff0318268ee1e19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/simplefs/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

