### PR TITLE
Add Secure Boot signing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ You can build the kernel module and tool with `make`.
 Generate test image via `make test.img`, which creates a zeroed file of 50 MiB.
 
 You can then mount this image on a system with the simplefs kernel module installed.
+As many computers now have UEFI Secure Boot enabled, you can either disable Secure Boot
+or sign the kernel module. To sign the module, refer to [secure-boot-signing-guide.md](./secure-boot-signing-guide.md).
+
 Let's test kernel module:
 ```shell
 $ sudo insmod simplefs.ko

--- a/secure-boot-signing-guide.md
+++ b/secure-boot-signing-guide.md
@@ -1,0 +1,69 @@
+# Secure Boot Kernel Module Signing Guide
+
+To insert the `simplefs.ko` kernel module, you can either
+disable secure boot or sign the module.
+
+In this guide, we assume you are using Ubuntu, but for
+other distributions it just need the same procedures.
+
+## Step 1: Install Dependencies
+
+You need to install linux kernel header, `mokutil`, `kmod`, and `openssl`.
+
+For Ubuntu you can install by these commands:
+
+```bash
+$ sudo apt install linux-headers-$(uname -r)
+$ sudo apt install mokutil kmod openssl
+```
+
+## Step 2: Generate a MOK Key Pair
+
+Create a private and a public certificate (DER format) to sign your modules:
+
+```bash
+$ cat << 'EOF' > mokconfig.cnf
+[ req ]
+default_bits       = 2048
+distinguished_name = req_distinguished_name
+prompt             = no
+x509_extensions    = myexts
+
+[ req_distinguished_name ]
+CN = simplefs MOK Signing Key 
+
+[ myexts ]
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid
+EOF
+
+openssl req -new -x509 -newkey rsa:2048 -nodes -days 3650 -outform DER -keyout MOK.priv -out MOK.der -config mokconfig.cnf
+```
+
+## Step 3. Enroll the Key with MOKutil
+
+Register your new public key with the shim bootloader. You will be prompted to create a temporary password for the next step.
+
+```bash
+$ sudo mokutil --import MOK.der
+```
+
+## Step 4. Complete Enrollment in UEFI
+
+1. **Reboot** your computer.
+2. Upon booting, the blue **MOK Manager** screen will automatically appear.
+3. Select **Enroll MOK** -> **View key** to verify your key details, then confirm the enrollment.
+4. Enter the temporary **password** you created in Step 3.
+5. Continue to boot into Linux.
+
+## Step 5. Sign `simplefs.ko`
+
+```bash
+# Sign 'simplefs.ko' 
+#$sudo /usr/src/linux-headers-`uname -r`/scripts/sign-file sha256 MOK.priv MOK.der /path/to/simplefs.ko
+
+# Optional: verify the signature is present
+$ modinfo /path/to/simplefs.ko | grep -i "signer"
+```


### PR DESCRIPTION
Add Secure Boot signing guide.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Secure Boot signing guide and link it from the README so users can load `simplefs.ko` on UEFI Secure Boot systems. The guide shows Ubuntu commands to install `linux-headers-$(uname -r)`, `mokutil`, `kmod`, and `openssl`; generate and enroll a MOK key via `mokutil`/MOK Manager; sign the module and verify with `modinfo`—with the README noting disabling Secure Boot as an alternative.

<sup>Written for commit 06da008e331c92367c49591c286e6ca6d9a5c9e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/simplefs/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

