### PR TITLE
fix: ensure forward progress in __file_lookup when nr_blk = 0

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -186,6 +186,14 @@ static int __file_lookup(struct inode *dir,
                     *fi = _fi;
                     return 0;
                 }
+                if(!dblock->files[_fi].nr_blk){
+                    /*
+                    this means the _ei and _bi we're looking for is looking at an empty block.
+                    we have to advance nontheless, but nr_blk would just add 0 to fi, causing endless loop.
+                    so we skip this entry by 1, just in case.
+                    */
+                    _fi += 1;
+                }
                 _fi += dblock->files[_fi].nr_blk;
             }
             RELEASE_BUFFER_HEAD(*ret_bi_bh);

--- a/inode.c
+++ b/inode.c
@@ -186,11 +186,12 @@ static int __file_lookup(struct inode *dir,
                     *fi = _fi;
                     return 0;
                 }
-                if(!dblock->files[_fi].nr_blk){
+                if(!dblock->files[_fi].nr_blk) {
                     /*
-                    this means the _ei and _bi we're looking for is looking at an empty block.
-                    we have to advance nontheless, but nr_blk would just add 0 to fi, causing endless loop.
-                    so we skip this entry by 1, just in case.
+                    this means the _ei and _bi we're looking for is looking at 
+                    an empty block. we have to advance nontheless, but nr_blk
+                    would just add 0 to fi, causing endless loop. so we skip
+                    this entry by 1, just in case.
                     */
                     _fi += 1;
                 }

--- a/inode.c
+++ b/inode.c
@@ -186,16 +186,17 @@ static int __file_lookup(struct inode *dir,
                     *fi = _fi;
                     return 0;
                 }
-                if(!dblock->files[_fi].nr_blk) {
+                if (!dblock->files[_fi].nr_blk) {
                     /*
-                    this means the _ei and _bi we're looking for is looking at 
+                    this means the _ei and _bi we're looking for is looking at
                     an empty block. we have to advance nontheless, but nr_blk
                     would just add 0 to fi, causing endless loop. so we skip
                     this entry by 1, just in case.
                     */
                     _fi += 1;
+                } else {
+                    _fi += dblock->files[_fi].nr_blk;
                 }
-                _fi += dblock->files[_fi].nr_blk;
             }
             RELEASE_BUFFER_HEAD(*ret_bi_bh);
         }


### PR DESCRIPTION
At __file_lookup, it sets its starting index to look for files using hashes. Unfortunately, in some cases, that points to an uninitialised dir entry, which sets nr_blk to 0, and adds nothing at

```
_fi += dblock->files[_fi].nr_blk;
```

which causes a soft lockup in some cases.
This commit fixes that by adding 1 to _fi index when nr_blk is 0, to ensure that the index moves by 1 when nr_blk is 0, which would mean it is an invalid dir entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent infinite loop in __file_lookup by advancing the file index when nr_blk == 0. Skip the empty entry by 1 to ensure forward progress; otherwise add nr_blk, with clearer inline comments and small style cleanup.

<sup>Written for commit 444918aa0440f488f01da7b8e990867f00bd667d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/simplefs/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

