### PR TITLE
Fix post-remount soft-lockup by persisting new directory block init

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -430,6 +430,7 @@ static int simplefs_get_new_ext(struct super_block *sb,
         dblock = (struct simplefs_dir_block *) bh->b_data;
         memset(dblock, 0, sizeof(struct simplefs_dir_block));
         dblock->files[0].nr_blk = SIMPLEFS_FILES_PER_BLOCK;
+        mark_buffer_dirty(bh);
         RELEASE_BUFFER_HEAD(bh);
     }
     return 0;


### PR DESCRIPTION
# Root cause
get_free_blocks() (bitmap.h) zeroes each of the 8 blocks (SIMPLEFS_MAX_BLOCKS_PER_EXTENT) of a new extent and sync_dirty_buffer()s them → on disk every block is all-zero.

simplefs_get_new_ext() (inode.c) writes files[0].nr_blk = SIMPLEFS_FILES_PER_BLOCK into each block, but releases the buffer with brelse() only — no mark_buffer_dirty() — so the initialization lives only in the page cache and is never written back.

simplefs_create() inserts the file into a single block and marks only that block (and the ei_block) dirty. The remaining blocks of the extent are never dirtied → they stay all-zero on disk.

On unmount, simplefs_put_super() does sync_blockdev(), flushes only dirty buffers(drops the cached). On remount the blocks are read from disk as {inode: 0, nr_blk: 0}.

Closes #89

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist directory block initialization by marking new dir block buffers dirty in `simplefs_get_new_ext()`, preventing post-remount soft-lockups.

- **Bug Fixes**
  - Call `mark_buffer_dirty(bh)` after setting `files[0].nr_blk = SIMPLEFS_FILES_PER_BLOCK` so the init is written to disk.
  - Prevents remount reading `nr_blk == 0`, which caused `__file_lookup()` to loop and soft-lock the kernel.

<sup>Written for commit a75f22ef8a9d7774fe90456f0954631bcc57d5c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sysprog21/simplefs/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

